### PR TITLE
Add `terraform.resources` function without schema

### DIFF
--- a/opa/conversion.go
+++ b/opa/conversion.go
@@ -1,0 +1,115 @@
+package opa
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/open-policy-agent/opa/types"
+)
+
+var rangeTy = types.NewObject(
+	[]*types.StaticProperty{
+		types.NewStaticProperty("filename", types.S),
+		types.NewStaticProperty("start", posTy),
+		types.NewStaticProperty("end", posTy),
+	},
+	nil,
+)
+
+var posTy = types.NewObject(
+	[]*types.StaticProperty{
+		types.NewStaticProperty("line", types.N),
+		types.NewStaticProperty("column", types.N),
+		types.NewStaticProperty("bytes", types.N),
+	},
+	nil,
+)
+
+func rangeToJSON(rng hcl.Range) map[string]any {
+	return map[string]any{
+		"filename": rng.Filename,
+		"start":    posToJSON(rng.Start),
+		"end":      posToJSON(rng.End),
+	}
+}
+
+func jsonToRange(in any, path string) (hcl.Range, error) {
+	rng, err := jsonToObject(in, path)
+	if err != nil {
+		return hcl.Range{}, err
+	}
+
+	filename, err := jsonToString(rng["filename"], fmt.Sprintf("%s.filename", path))
+	if err != nil {
+		return hcl.Range{}, err
+	}
+	start, err := jsonToPos(rng["start"], fmt.Sprintf("%s.start", path))
+	if err != nil {
+		return hcl.Range{}, err
+	}
+	end, err := jsonToPos(rng["end"], fmt.Sprintf("%s.end", path))
+	if err != nil {
+		return hcl.Range{}, err
+	}
+
+	return hcl.Range{Filename: filename, Start: start, End: end}, nil
+}
+
+func posToJSON(pos hcl.Pos) map[string]int {
+	return map[string]int{
+		"line":   pos.Line,
+		"column": pos.Column,
+		"bytes":  pos.Byte,
+	}
+}
+
+func jsonToPos(in any, path string) (hcl.Pos, error) {
+	pos, err := jsonToObject(in, path)
+	if err != nil {
+		return hcl.Pos{}, err
+	}
+
+	line, err := jsonToInt(pos["line"], fmt.Sprintf("%s.line", path))
+	if err != nil {
+		return hcl.Pos{}, err
+	}
+	column, err := jsonToInt(pos["column"], fmt.Sprintf("%s.column", path))
+	if err != nil {
+		return hcl.Pos{}, err
+	}
+	bytes, err := jsonToInt(pos["bytes"], fmt.Sprintf("%s.bytes", path))
+	if err != nil {
+		return hcl.Pos{}, err
+	}
+
+	return hcl.Pos{Line: line, Column: column, Byte: bytes}, nil
+}
+
+func jsonToObject(in any, path string) (map[string]any, error) {
+	out, ok := in.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("%s is not object, got %T", path, in)
+	}
+	return out, nil
+}
+
+func jsonToString(in any, path string) (string, error) {
+	out, ok := in.(string)
+	if !ok {
+		return "", fmt.Errorf("%s is not string, got %T", path, in)
+	}
+	return out, nil
+}
+
+func jsonToInt(in any, path string) (int, error) {
+	jn, ok := in.(json.Number)
+	if !ok {
+		return 0, fmt.Errorf("%s is not a number, got %T", path, in)
+	}
+	num, err := jn.Int64()
+	if err != nil {
+		return 0, err
+	}
+	return int(num), nil
+}

--- a/opa/engine.go
+++ b/opa/engine.go
@@ -12,18 +12,11 @@ import (
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
 )
 
-// Engine evaluates policies, generates a list of tflint.Rule,
-// and returns the results.
+// Engine evaluates policies and returns the results.
 // In other words, this is a wrapper of rego.New(...).Eval().
 type Engine struct {
 	store   storage.Store
 	modules map[string]*ast.Module
-
-	rules []tflint.Rule
-}
-
-func EmptyEmgine() *Engine {
-	return &Engine{}
 }
 
 // NewEngine returns a new engine based on the policies loaded
@@ -33,19 +26,9 @@ func NewEngine(ret *loader.Result) (*Engine, error) {
 		return nil, err
 	}
 
-	var rules []tflint.Rule
-	for _, module := range ret.ParsedModules() {
-		for _, rule := range module.Rules {
-			if r := NewRule(rule.Head.Name.String()); r != nil {
-				rules = append(rules, r)
-			}
-		}
-	}
-
 	return &Engine{
 		store:   store,
 		modules: ret.ParsedModules(),
-		rules:   rules,
 	}, nil
 }
 

--- a/opa/engine.go
+++ b/opa/engine.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/hcl/v2"
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/loader"
 	"github.com/open-policy-agent/opa/rego"
@@ -38,6 +39,7 @@ func NewEngine(ret *loader.Result) (*Engine, error) {
 type Result struct {
 	message  string
 	severity tflint.Severity
+	location hcl.Range
 }
 
 // RunQuery executes a query referencing a rule and returns the generated
@@ -46,23 +48,24 @@ type Result struct {
 //
 // - All rules should be under the "tflint" package
 // - Rule should return a Set document
-// - The elements of the set must be objects consisting of "message" and "severity".
+// - The elements of the set must be objects consisting of "message" and "severity", and "location".
 //
 // Example:
 //
 // ```
 //
 //	deny_test[issue] {
-//	  [decision]
+//	  [condition]
 //
 //	  issue := {
 //	    "message": "test",
-//	    "severity": "error"
+//	    "severity": "error",
+//	    "location": resource.decl_range
 //	  }
 //	}
 //
 // ```
-func (e *Engine) RunQuery(rule *Rule) ([]*Result, error) {
+func (e *Engine) RunQuery(rule *Rule, runner tflint.Runner) ([]*Result, error) {
 	regoOpts := []func(*rego.Rego){
 		// All rules should be under the "tflint" package
 		rego.Query(fmt.Sprintf("data.tflint.%s", rule.RegoName())),
@@ -72,6 +75,8 @@ func (e *Engine) RunQuery(rule *Rule) ([]*Result, error) {
 	for _, m := range e.modules {
 		regoOpts = append(regoOpts, rego.ParsedModule(m))
 	}
+
+	regoOpts = append(regoOpts, Functions(runner)...)
 
 	rs, err := rego.New(regoOpts...).Eval(context.Background())
 	if err != nil {
@@ -87,26 +92,11 @@ func (e *Engine) RunQuery(rule *Rule) ([]*Result, error) {
 			}
 
 			for _, value := range values {
-				issue, ok := value.(map[string]any)
-				if !ok {
-					return nil, fmt.Errorf("issue is not object, got %T", value)
-				}
-
-				message, ok := issue["message"].(string)
-				if !ok {
-					return nil, fmt.Errorf("message is not string, got %T", issue["message"])
-				}
-
-				severityStr, ok := issue["severity"].(string)
-				if !ok {
-					return nil, fmt.Errorf("severity is not string, got %T", issue["severity"])
-				}
-				severity, err := asSeverity(severityStr)
+				ret, err := jsonToResult(value, "issue")
 				if err != nil {
 					return nil, err
 				}
-
-				results = append(results, &Result{message: message, severity: severity})
+				results = append(results, ret)
 			}
 		}
 	}
@@ -114,8 +104,35 @@ func (e *Engine) RunQuery(rule *Rule) ([]*Result, error) {
 	return results, err
 }
 
-func asSeverity(in string) (tflint.Severity, error) {
-	switch strings.ToLower(in) {
+func jsonToResult(in any, path string) (*Result, error) {
+	ret, err := jsonToObject(in, path)
+	if err != nil {
+		return nil, err
+	}
+
+	message, err := jsonToString(ret["message"], fmt.Sprintf("%s.message", path))
+	if err != nil {
+		return nil, err
+	}
+	severity, err := jsonToSeverity(ret["severity"], fmt.Sprintf("%s.severity", path))
+	if err != nil {
+		return nil, err
+	}
+	location, err := jsonToRange(ret["location"], fmt.Sprintf("%s.location", path))
+	if err != nil {
+		return nil, err
+	}
+
+	return &Result{message: message, severity: severity, location: location}, nil
+}
+
+func jsonToSeverity(in any, path string) (tflint.Severity, error) {
+	severity, err := jsonToString(in, path)
+	if err != nil {
+		return tflint.ERROR, err
+	}
+
+	switch strings.ToLower(severity) {
 	case "error":
 		return tflint.ERROR, nil
 	case "warning":
@@ -123,6 +140,6 @@ func asSeverity(in string) (tflint.Severity, error) {
 	case "notice":
 		return tflint.NOTICE, nil
 	default:
-		return tflint.ERROR, fmt.Errorf("invalid severity: %s", in)
+		return tflint.ERROR, fmt.Errorf("%s is invalid: %s", path, in)
 	}
 }

--- a/opa/function.go
+++ b/opa/function.go
@@ -1,0 +1,129 @@
+package opa
+
+import (
+	"fmt"
+
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/rego"
+	"github.com/open-policy-agent/opa/types"
+	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
+	"github.com/terraform-linters/tflint-plugin-sdk/logger"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+)
+
+// Functions return custom functions as Rego options.
+func Functions(runner tflint.Runner) []func(*rego.Rego) {
+	return []func(*rego.Rego){
+		resourcesFunc(runner),
+	}
+}
+
+// terraform.resources: resources := terraform.resources(resource_type)
+//
+// Returns Terraform resources.
+//
+//	resource_type (string): resource type to retrieve. "*" is a special character that returns all resources.
+//
+// Returns:
+//
+//	resources (array[object<type: string, name: string, config: object[string: any], decl_range: rangeTy, type_range: rangeTy>]) Terraform resources
+func resourcesFunc(runner tflint.Runner) func(*rego.Rego) {
+	return rego.Function1(
+		&rego.Function{
+			Name: "terraform.resources",
+			Decl: types.NewFunction(
+				types.Args(types.S),
+				types.NewArray(
+					nil,
+					types.NewObject(
+						[]*types.StaticProperty{
+							types.NewStaticProperty("type", types.S),
+							types.NewStaticProperty("name", types.S),
+							types.NewStaticProperty("config", types.NewObject(nil, types.NewDynamicProperty(types.S, types.A))),
+							types.NewStaticProperty("decl_range", rangeTy),
+							types.NewStaticProperty("type_range", rangeTy),
+						},
+						nil,
+					),
+				),
+			),
+			Memoize:          true,
+			Nondeterministic: true,
+		},
+		func(_ rego.BuiltinContext, a *ast.Term) (*ast.Term, error) {
+			var resourceType string
+			if err := ast.As(a.Value, &resourceType); err != nil {
+				return nil, err
+			}
+
+			var content *hclext.BodyContent
+			var err error
+			// "*" is a special character that returns all resources
+			if resourceType == "*" {
+				content, err = runner.GetModuleContent(&hclext.BodySchema{
+					Blocks: []hclext.BlockSchema{
+						{
+							Type:       "resource",
+							LabelNames: []string{"type", "name"},
+						},
+					},
+				}, nil)
+			} else {
+				content, err = runner.GetResourceContent(resourceType, nil, nil)
+			}
+			if err != nil {
+				return nil, err
+			}
+
+			v, err := ast.InterfaceToValue(resourcesToJSON(content.Blocks))
+			if err != nil {
+				return nil, err
+			}
+			logger.Debug(fmt.Sprintf(`terraform.resoures("%s"): %s`, resourceType, v))
+
+			return ast.NewTerm(v), nil
+		},
+	)
+}
+
+func resourcesToJSON(in hclext.Blocks) []map[string]any {
+	ret := make([]map[string]any, len(in))
+
+	for i, block := range in {
+		ret[i] = map[string]any{
+			"type":       block.Labels[0],
+			"name":       block.Labels[1],
+			"config":     bodyToJSON(block.Body),
+			"decl_range": rangeToJSON(block.DefRange),
+			"type_range": rangeToJSON(block.LabelRanges[0]),
+		}
+	}
+	return ret
+}
+
+func bodyToJSON(in *hclext.BodyContent) map[string]any {
+	ret := map[string]any{}
+
+	// TODO: attributes
+
+	for _, block := range in.Blocks {
+		switch r := ret[block.Type].(type) {
+		case nil:
+			ret[block.Type] = []map[string]any{blockToJSON(block)}
+		case []map[string]any:
+			ret[block.Type] = append(r, blockToJSON(block))
+		default:
+			panic(fmt.Sprintf("unknown type: %T", ret[block.Type]))
+		}
+	}
+
+	return ret
+}
+
+func blockToJSON(in *hclext.Block) map[string]any {
+	return map[string]any{
+		"type":   in.Type,
+		"labels": in.Labels,
+		"body":   bodyToJSON(in.Body),
+	}
+}

--- a/opa/rule.go
+++ b/opa/rule.go
@@ -4,12 +4,15 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/hcl/v2"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
 )
 
 // Rule is a container for rules defined by Rego to satisfy tflint.Rule
 type Rule struct {
 	tflint.DefaultRule
+
+	engine *Engine
 
 	name     string
 	regoName string
@@ -20,13 +23,14 @@ var _ tflint.Rule = (*Rule)(nil)
 
 // NewRule returns a tflint.Rule from rule name in Rego.
 // Note that the rule names in TFLint and in Rego are different.
-func NewRule(regoName string) *Rule {
+func NewRule(regoName string, engine *Engine) *Rule {
 	// All valid rules must start with "deny_" (e.g. deny_test)
 	if !strings.HasPrefix(regoName, "deny_") {
 		return nil
 	}
 
 	return &Rule{
+		engine: engine,
 		// Add "opa_" to the rule name in TFLint (e.g. opa_deny_test)
 		name:     fmt.Sprintf("opa_%s", regoName),
 		regoName: regoName,
@@ -45,9 +49,18 @@ func (r *Rule) Severity() tflint.Severity {
 	return r.severity
 }
 
-// Check is a dummy just to fill the interface.
-// See RuleSet.Check for actual inspection.
-func (r *Rule) Check(tflint.Runner) error {
+func (r *Rule) Check(runner tflint.Runner) error {
+	results, err := r.engine.RunQuery(r)
+	if err != nil {
+		return err
+	}
+
+	for _, ret := range results {
+		if err := runner.EmitIssue(r.WithSeverity(ret.severity), ret.message, hcl.Range{}); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/opa/ruleset.go
+++ b/opa/ruleset.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/hashicorp/hcl/v2"
 	"github.com/open-policy-agent/opa/loader"
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
@@ -16,7 +15,6 @@ type RuleSet struct {
 	tflint.BuiltinRuleSet
 
 	config *tflint.Config
-	engine *Engine
 }
 
 // ApplyGlobalConfig is normally not expected to be overridden,
@@ -30,12 +28,9 @@ func (r *RuleSet) ApplyGlobalConfig(config *tflint.Config) error {
 }
 
 // ApplyConfig loads policies from ~/.tflint.d/policies
-// and initialize a policy engine.
-// The engine will generate rules from the compiled policies
-// and it run ApplyGlobalConfig.
+// and generates TFLint rules.
+// Run ApplyGlobalConfig after the rules are generated.
 func (r *RuleSet) ApplyConfig(body *hclext.BodyContent) error {
-	r.engine = EmptyEmgine()
-
 	homedir, err := os.UserHomeDir()
 	if err != nil {
 		return err
@@ -58,32 +53,18 @@ func (r *RuleSet) ApplyConfig(body *hclext.BodyContent) error {
 		return fmt.Errorf("failed to load policies; %w", err)
 	}
 
-	r.engine, err = NewEngine(ret)
+	engine, err := NewEngine(ret)
 	if err != nil {
 		return fmt.Errorf("failed to initialize a policy engine; %w", err)
 	}
 
-	r.Rules = r.engine.rules
-
-	return r.BuiltinRuleSet.ApplyGlobalConfig(r.config)
-}
-
-// Check runs queries and emits issues by results
-func (r *RuleSet) Check(runner tflint.Runner) error {
-	for _, rule := range r.EnabledRules {
-		rule := rule.(*Rule)
-
-		results, err := r.engine.RunQuery(rule)
-		if err != nil {
-			return fmt.Errorf(`failed to check "%s" rule; %w`, rule.Name(), err)
-		}
-
-		for _, ret := range results {
-			if err := runner.EmitIssue(rule.WithSeverity(ret.severity), ret.message, hcl.Range{}); err != nil {
-				return fmt.Errorf(`failed to emit "%s" rule issue; %w`, rule.Name(), err)
+	for _, module := range ret.ParsedModules() {
+		for _, regoRule := range module.Rules {
+			if rule := NewRule(regoRule.Head.Name.String(), engine); rule != nil {
+				r.Rules = append(r.Rules, rule)
 			}
 		}
 	}
 
-	return nil
+	return r.BuiltinRuleSet.ApplyGlobalConfig(r.config)
 }

--- a/opa/ruleset.go
+++ b/opa/ruleset.go
@@ -60,7 +60,7 @@ func (r *RuleSet) ApplyConfig(body *hclext.BodyContent) error {
 
 	for _, module := range ret.ParsedModules() {
 		for _, regoRule := range module.Rules {
-			if rule := NewRule(regoRule.Head.Name.String(), engine); rule != nil {
+			if rule := NewRule(regoRule, engine); rule != nil {
 				r.Rules = append(r.Rules, rule)
 			}
 		}


### PR DESCRIPTION
This PR adds the `terraform.resources` function as a first step to support Terraform configuration. This allows us to write policies like the following:

```rego
package tflint

deny_not_snake_case[issue] {
  resources := terraform.resources("aws_instance")
  not regex.match("^[a-z][a-z0-9]*(_[a-z0-9]+)*$", resources[i].name)

  issue := {
    "message": sprintf("%s is not snake case", [resources[i].name]),
    "severity": "error",
    "location": resources[i].decl_range
  }
}
```

Issues are reported as follows:

```console
$ tflint
1 issue(s) found:

Error: main-v2 is not snake case (opa_deny_not_snake_case)

  on main.tf line 1:
   1: resource "aws_instance" "main-v2" {

Reference: /home/codespace/.tflint.d/policies/test.rego:3
```

Note that attributes in the body such as `instance_type` are not yet supported. To support these, schema and evaluation are required and will be implemented in the next step.