### PR TITLE
Add support for retrieving resources based on schema

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/hashicorp/hcl/v2 v2.15.0
 	github.com/open-policy-agent/opa v0.47.4
 	github.com/terraform-linters/tflint-plugin-sdk v0.15.0
+	github.com/zclconf/go-cty v1.12.1
 )
 
 require (
@@ -35,7 +36,6 @@ require (
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/yashtewari/glob-intersection v0.1.0 // indirect
-	github.com/zclconf/go-cty v1.12.1 // indirect
 	golang.org/x/net v0.4.0 // indirect
 	golang.org/x/sys v0.3.0 // indirect
 	golang.org/x/text v0.5.0 // indirect

--- a/opa/conversion.go
+++ b/opa/conversion.go
@@ -8,23 +8,15 @@ import (
 	"github.com/open-policy-agent/opa/types"
 )
 
-var rangeTy = types.NewObject(
+// range (object<filename: string, start: pos, end: pos>): range of a source file in HCL
+var rangeTy = types.Named("range", types.NewObject(
 	[]*types.StaticProperty{
 		types.NewStaticProperty("filename", types.S),
 		types.NewStaticProperty("start", posTy),
 		types.NewStaticProperty("end", posTy),
 	},
 	nil,
-)
-
-var posTy = types.NewObject(
-	[]*types.StaticProperty{
-		types.NewStaticProperty("line", types.N),
-		types.NewStaticProperty("column", types.N),
-		types.NewStaticProperty("bytes", types.N),
-	},
-	nil,
-)
+)).Description("range of a source file in HCL")
 
 func rangeToJSON(rng hcl.Range) map[string]any {
 	return map[string]any{
@@ -55,6 +47,16 @@ func jsonToRange(in any, path string) (hcl.Range, error) {
 
 	return hcl.Range{Filename: filename, Start: start, End: end}, nil
 }
+
+// pos (object<line: number, column: number, bytes: number>): position of a source file in HCL
+var posTy = types.Named("pos", types.NewObject(
+	[]*types.StaticProperty{
+		types.NewStaticProperty("line", types.N),
+		types.NewStaticProperty("column", types.N),
+		types.NewStaticProperty("bytes", types.N),
+	},
+	nil,
+)).Description("position of a source file in HCL")
 
 func posToJSON(pos hcl.Pos) map[string]int {
 	return map[string]int{

--- a/opa/function.go
+++ b/opa/function.go
@@ -1,14 +1,18 @@
 package opa
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
 
+	"github.com/hashicorp/hcl/v2"
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/rego"
 	"github.com/open-policy-agent/opa/types"
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
-	"github.com/terraform-linters/tflint-plugin-sdk/logger"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/zclconf/go-cty/cty"
+	ctyjson "github.com/zclconf/go-cty/cty/json"
 )
 
 // Functions return custom functions as Rego options.
@@ -18,46 +22,42 @@ func Functions(runner tflint.Runner) []func(*rego.Rego) {
 	}
 }
 
-// terraform.resources: resources := terraform.resources(resource_type)
+// terraform.resources: resources := terraform.resources(resource_type, schema)
 //
 // Returns Terraform resources.
 //
 //	resource_type (string): resource type to retrieve. "*" is a special character that returns all resources.
+//	schema        (schema): Schema for attributes referenced in rules.
 //
 // Returns:
 //
-//	resources (array[object<type: string, name: string, config: object[string: any], decl_range: rangeTy, type_range: rangeTy>]) Terraform resources
+//	resources (array[resource]) Terraform resources
 func resourcesFunc(runner tflint.Runner) func(*rego.Rego) {
-	return rego.Function1(
+	return rego.Function2(
 		&rego.Function{
 			Name: "terraform.resources",
 			Decl: types.NewFunction(
-				types.Args(types.S),
-				types.NewArray(
-					nil,
-					types.NewObject(
-						[]*types.StaticProperty{
-							types.NewStaticProperty("type", types.S),
-							types.NewStaticProperty("name", types.S),
-							types.NewStaticProperty("config", types.NewObject(nil, types.NewDynamicProperty(types.S, types.A))),
-							types.NewStaticProperty("decl_range", rangeTy),
-							types.NewStaticProperty("type_range", rangeTy),
-						},
-						nil,
-					),
-				),
+				types.Args(types.S, schemaTy),
+				types.NewArray(nil, resourceTy),
 			),
 			Memoize:          true,
 			Nondeterministic: true,
 		},
-		func(_ rego.BuiltinContext, a *ast.Term) (*ast.Term, error) {
+		func(_ rego.BuiltinContext, a *ast.Term, b *ast.Term) (*ast.Term, error) {
 			var resourceType string
 			if err := ast.As(a.Value, &resourceType); err != nil {
 				return nil, err
 			}
+			var schemaJSON map[string]any
+			if err := ast.As(b.Value, &schemaJSON); err != nil {
+				return nil, err
+			}
+			schema, err := jsonToSchema(schemaJSON, "schema")
+			if err != nil {
+				return nil, err
+			}
 
 			var content *hclext.BodyContent
-			var err error
 			// "*" is a special character that returns all resources
 			if resourceType == "*" {
 				content, err = runner.GetModuleContent(&hclext.BodySchema{
@@ -65,65 +65,223 @@ func resourcesFunc(runner tflint.Runner) func(*rego.Rego) {
 						{
 							Type:       "resource",
 							LabelNames: []string{"type", "name"},
+							Body:       schema,
 						},
 					},
 				}, nil)
 			} else {
-				content, err = runner.GetResourceContent(resourceType, nil, nil)
+				content, err = runner.GetResourceContent(resourceType, schema, nil)
 			}
 			if err != nil {
 				return nil, err
 			}
 
-			v, err := ast.InterfaceToValue(resourcesToJSON(content.Blocks))
+			resources, err := resourcesToJSON(content.Blocks, runner)
 			if err != nil {
 				return nil, err
 			}
-			logger.Debug(fmt.Sprintf(`terraform.resoures("%s"): %s`, resourceType, v))
+			v, err := ast.InterfaceToValue(resources)
+			if err != nil {
+				return nil, err
+			}
 
 			return ast.NewTerm(v), nil
 		},
 	)
 }
 
-func resourcesToJSON(in hclext.Blocks) []map[string]any {
-	ret := make([]map[string]any, len(in))
+// schema (object[string: any<string, schema>]): representation of body schema
+var schemaTy = types.Named("schema", types.NewObject(
+	nil,
+	// Same as types.NewDynamicProperty(types.S, types.Or(types.S, schemaTy)). Recursive type is not supported.
+	types.NewDynamicProperty(types.S, types.A),
+)).Description("representation of body schema")
 
-	for i, block := range in {
+func jsonToSchema(in map[string]any, path string) (*hclext.BodySchema, error) {
+	schema := &hclext.BodySchema{}
+
+	for k, v := range in {
+		switch cv := v.(type) {
+		case string:
+			schema.Attributes = append(schema.Attributes, hclext.AttributeSchema{Name: k})
+
+		case map[string]any:
+			inner, err := jsonToSchema(cv, fmt.Sprintf("%s.%s", path, k))
+			if err != nil {
+				return schema, err
+			}
+			schema.Blocks = append(schema.Blocks, hclext.BlockSchema{
+				Type: k,
+				Body: inner,
+			})
+
+		default:
+			return schema, fmt.Errorf("%s.%s is not string or object, got %T", path, k, v)
+		}
+	}
+
+	return schema, nil
+}
+
+// resource (object<type: string, name: string, config: body, decl_range: range, type_range: range>): representation of "resource" blocks
+var resourceTy = types.Named("resource", types.NewObject(
+	[]*types.StaticProperty{
+		types.NewStaticProperty("type", types.S),
+		types.NewStaticProperty("name", types.S),
+		types.NewStaticProperty("config", bodyTy),
+		types.NewStaticProperty("decl_range", rangeTy),
+		types.NewStaticProperty("type_range", rangeTy),
+	},
+	nil,
+)).Description(`representation of "resource" blocks`)
+
+func resourcesToJSON(resources hclext.Blocks, runner tflint.Runner) ([]map[string]any, error) {
+	ret := make([]map[string]any, len(resources))
+
+	for i, block := range resources {
+		body, err := bodyToJSON(block.Body, runner)
+		if err != nil {
+			return ret, err
+		}
+
 		ret[i] = map[string]any{
 			"type":       block.Labels[0],
 			"name":       block.Labels[1],
-			"config":     bodyToJSON(block.Body),
+			"config":     body,
 			"decl_range": rangeToJSON(block.DefRange),
 			"type_range": rangeToJSON(block.LabelRanges[0]),
 		}
 	}
-	return ret
+	return ret, nil
 }
 
-func bodyToJSON(in *hclext.BodyContent) map[string]any {
+// body (object[string: any<expr, array[block]>]): representation of config body
+var bodyTy = types.Named("body", types.NewObject(
+	nil,
+	types.NewDynamicProperty(
+		types.S,
+		types.Or(exprTy, types.NewArray(nil, blockTy)),
+	)),
+).Description("representation of config body")
+
+func bodyToJSON(body *hclext.BodyContent, runner tflint.Runner) (map[string]any, error) {
 	ret := map[string]any{}
 
-	// TODO: attributes
+	for _, attr := range body.Attributes {
+		value, err := exprToJSON(attr.Expr, runner)
+		if err != nil {
+			return ret, err
+		}
 
-	for _, block := range in.Blocks {
+		ret[attr.Name] = value
+	}
+
+	for _, block := range body.Blocks {
+		json, err := blockToJSON(block, runner)
+		if err != nil {
+			return ret, err
+		}
+
 		switch r := ret[block.Type].(type) {
 		case nil:
-			ret[block.Type] = []map[string]any{blockToJSON(block)}
+			ret[block.Type] = []map[string]any{json}
 		case []map[string]any:
-			ret[block.Type] = append(r, blockToJSON(block))
+			ret[block.Type] = append(r, json)
 		default:
 			panic(fmt.Sprintf("unknown type: %T", ret[block.Type]))
 		}
 	}
 
-	return ret
+	return ret, nil
 }
 
-func blockToJSON(in *hclext.Block) map[string]any {
-	return map[string]any{
-		"type":   in.Type,
-		"labels": in.Labels,
-		"body":   bodyToJSON(in.Body),
+// expr (object<value: any, unknown: boolean, sensitive: boolean, range: range>): representation of expressions
+var exprTy = types.Named("expr", types.NewObject(
+	[]*types.StaticProperty{
+		types.NewStaticProperty("value", types.A),
+		types.NewStaticProperty("unknown", types.B),
+		types.NewStaticProperty("sensitive", types.B),
+		types.NewStaticProperty("range", rangeTy),
+	},
+	nil,
+)).Description("representation of expressions")
+
+func exprToJSON(expr hcl.Expression, runner tflint.Runner) (map[string]any, error) {
+	ret := map[string]any{
+		"unknown":   false,
+		"sensitive": false,
+		"range":     rangeToJSON(expr.Range()),
 	}
+
+	var value cty.Value
+	err := runner.EvaluateExpr(expr, &value, nil)
+	if err != nil {
+		if errors.Is(err, tflint.ErrSensitive) {
+			// "value" is undefined to halt evaluation if the value is unknown
+			ret["unknown"] = true
+			ret["sensitive"] = true
+			return ret, nil
+		}
+		return ret, err
+	}
+	if !value.IsWhollyKnown() {
+		ret["unknown"] = true
+		return ret, nil
+	}
+
+	// Convert cty.Value to JSON representation and unmarshal as any type.
+	// This allows values of any type to be valid JSON values.
+	out, err := ctyjson.Marshal(value, value.Type())
+	if err != nil {
+		return ret, fmt.Errorf("internal marshal error: %w", err)
+	}
+	var val any
+	if err := json.Unmarshal(out, &val); err != nil {
+		return ret, fmt.Errorf("internal unmarshal error: %w", err)
+	}
+	ret["value"] = val
+
+	return ret, nil
+}
+
+// block (object<config: object[string: any<expr, array[block]>], decl_range: range>): representation of nested blocks
+var blockTy = types.Named("block", types.NewObject(
+	[]*types.StaticProperty{
+		types.NewStaticProperty("config", types.NewObject(
+			nil,
+			// Same as bodyTy
+			types.NewDynamicProperty(
+				types.S,
+				// Same as types.Or(exprTy, types.NewArray(nil, blockTy)
+				types.Or(exprTy, types.NewArray(nil, types.NewObject(
+					[]*types.StaticProperty{
+						types.NewStaticProperty("config", types.NewObject(
+							nil,
+							types.NewDynamicProperty(
+								types.S,
+								// block deeper than 3 levels should be any, as recursive type is not supported
+								types.Or(exprTy, types.NewArray(nil, types.A)),
+							)),
+						),
+						types.NewStaticProperty("decl_range", rangeTy),
+					},
+					nil,
+				))),
+			)),
+		),
+		types.NewStaticProperty("decl_range", rangeTy),
+	},
+	nil,
+)).Description("representation of nested blocks")
+
+func blockToJSON(block *hclext.Block, runner tflint.Runner) (map[string]any, error) {
+	body, err := bodyToJSON(block.Body, runner)
+	if err != nil {
+		return nil, err
+	}
+
+	return map[string]any{
+		"config":     body,
+		"decl_range": rangeToJSON(block.DefRange),
+	}, nil
 }


### PR DESCRIPTION
This PR adds support for a schema argument to `terraform.resources()` function, allowing you to reference arbitrary attributes. This allows us to write policies like the following:

```rego
deny_t3_nano[issue] {
  resources := terraform.resources("aws_instance", {"instance_type": "string"})
  instance_type := resources[_].config.instance_type

  instance_type.value == "t3.nano"

  issue := {
    "message": "t3.nano is not allowed",
    "severity": "error",
    "location": instance_type.range
  }
}
```

Nested attributes can be referenced as follows:

```rego
deny_large_volume[issue] {
  resources := terraform.resources("aws_instance", {"ebs_block_device": {"volume_size": "number"}})
  volume_size := resources[_].config.ebs_block_device[_].config.volume_size

  volume_size.value > 30

  issue := {
    "message": "Allowed volume size is less than 30 GB",
    "severity": "error",
    "location": volume_size.range
  }
}
```

A schema is an object with arbitrary string keys. The values have no special meaning except nested blocks, but they are recommended to write the types as comments.

Be careful with handling unknown values. Variables with no default value, variables marked sensitive, and expression values containing unsupported references are marked as unknown. Any unknown value causes `value` to be undefined, so any rules halt being evaluated and are ignored.

```rego
# Neither rule applies.

deny_t2_micro[issue] {
  resources := terraform.resources("aws_instance", {"instance_type": "string"})
  instance_type := resources[_].config.instance_type

  instance_type.value == "t2.micro"

  issue := {
    "message": "t2.micro is not allowed",
    "severity": "error",
    "location": instance_type.range
  }
}

deny_not_t2_micro[issue] {
  resources := terraform.resources("aws_instance", {"instance_type": "string"})
  instance_type := resources[_].config.instance_type

  instance_type.value != "t2.micro"

  issue := {
    "message": "t2.micro is only allowed",
    "severity": "error",
    "location": instance_type.range
  }
}
```

If you want to prevent unknown values from passing through the rule (e.g. you don't want to allow anything but t2.micro) you can also throw an error for unknown.

```rego
is_not_t2_micro(instance_type) {
  instance_type.value != "t2.micro"
}
is_not_t2_micro(instance_type) {
  instance_type.unknown == true
}

deny_not_t2_micro[issue] {
  resources := terraform.resources("aws_instance", {"instance_type": "string"})
  instance_type := resources[_].config.instance_type

  is_not_t2_micro(instance_type)

  issue := {
    "message": "t2.micro is only allowed",
    "severity": "error",
    "location": instance_type.range
  }
}
```

As a more advanced example, you can also detect untagged resources:

```rego
contains(array, elem) {
  array[_] = elem
}
is_not_tagged(config) {
  not contains(object.keys(config.tags.value), "Environment")
}
is_not_tagged(config) {
  not contains(object.keys(config), "tags")
}

deny_not_tagged_instance[issue] {
  resources := terraform.resources("aws_instance", {"tags": "map(string)"})
  resource := resources[_]

  is_not_tagged(resource.config)

  issue := {
    "message": "instance should be tagged with Environment",
    "severity": "error",
    "location": resource.decl_range
  }
}
```