### PR TITLE
Allow incremental rules

### DIFF
--- a/opa/ruleset.go
+++ b/opa/ruleset.go
@@ -58,8 +58,16 @@ func (r *RuleSet) ApplyConfig(body *hclext.BodyContent) error {
 		return fmt.Errorf("failed to initialize a policy engine; %w", err)
 	}
 
+	regoRuleNames := map[string]bool{}
 	for _, module := range ret.ParsedModules() {
 		for _, regoRule := range module.Rules {
+			ruleName := regoRule.Head.Name.String()
+			if _, exists := regoRuleNames[ruleName]; exists {
+				// Supports incremental rules, simply ignoring rules with the same name.
+				continue
+			}
+			regoRuleNames[ruleName] = true
+
 			if rule := NewRule(regoRule, engine); rule != nil {
 				r.Rules = append(r.Rules, rule)
 			}


### PR DESCRIPTION
This PR supports incremental rules by allowing duplicate rule names. This allows you to write queries like:

```rego
package tflint

deny_invalid_type[issue] {
  resources := terraform.resources("aws_instance", {"instance_type": "string"})
  instance_type := resources[_].config.instance_type

  instance_type.value != "t2.micro"

  issue := tflint.issue("t2.micro is only allowed", instance_type.range)
}

deny_invalid_type[issue] {
  resources := terraform.resources("aws_instance", {"instance_type": "string"})
  instance_type := resources[_].config.instance_type

  instance_type.unknown == true

  issue := tflint.issue("instance type is unknown, you need to add tflint-ignore annotation here", instance_type.range)
}
```

Note that if there are multiple rules, the issue reference will refer to the first line. For example, an issue that meets the second condition will still have line number 3, not 12.