### PR TITLE
Make the policy dir configurable

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77 // indirect
 	github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7 // indirect
 	github.com/oklog/run v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -108,6 +108,8 @@ github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/miekg/dns v1.1.43 h1:JKfpVSCB84vrAmHzyrsxB5NAr5kLoMXZArPSw7Qlgyg=
+github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
+github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77 h1:7GoSOOW2jpsfkntVKaS2rAr1TJqfcxotyaUcuxoZSzg=
 github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7 h1:DpOJ2HYzCv8LZP15IdmG+YdwD2luVPHITV96TkirNBM=

--- a/opa/config.go
+++ b/opa/config.go
@@ -1,0 +1,55 @@
+package opa
+
+import (
+	"os"
+
+	"github.com/mitchellh/go-homedir"
+)
+
+// Config is the configuration for the ruleset.
+type Config struct {
+	PolicyDir string `hclext:"policy_dir,optional"`
+}
+
+var (
+	policyRoot      = "~/.tflint.d/policies"
+	localPolicyRoot = "./.tflint.d/policies"
+)
+
+// policyDir returns the base policy directory.
+// Adopted with the following priorities:
+//
+//  1. `policy_dir` in a config file
+//  2. `TFLINT_OPA_POLICY_DIR` environment variable
+//  3. Current directory (./.tflint.d/policies)
+//  4. Home directory (~/.tflint.d/policies)
+//
+// If the environment variable is set, other directories will not be considered,
+// but if the current directory does not exist, it will fallback to the home directory.
+func (c *Config) policyDir() (string, error) {
+	if c.PolicyDir != "" {
+		return homedir.Expand(c.PolicyDir)
+	}
+
+	if dir := os.Getenv("TFLINT_OPA_POLICY_DIR"); dir != "" {
+		return dir, nil
+	}
+
+	_, err := os.Stat(localPolicyRoot)
+	if os.IsNotExist(err) {
+		return policyRootDir()
+	}
+
+	return localPolicyRoot, err
+}
+
+func policyRootDir() (string, error) {
+	dir, err := homedir.Expand(policyRoot)
+	if err != nil {
+		return "", err
+	}
+
+	// Returning os.ErrNotExist allows checking to continue even if it doesn't exist
+	_, err = os.Stat(dir)
+	return dir, err
+}


### PR DESCRIPTION
This PR allows changing the policy directory in various ways.

The first is the declaration in the config file. This allows different policies to be applied to each module when used with `--recursive`. For example:

```hcl
plugin "opa" {
  enabled = true

  policy_dir = "tflint/policies"
}
```

The second is environment variables. You can change the directory using `TFLINT_OPA_POLICY_DIR`.

The last is `./.tflint.d/policies` support. Similar to the plugin directory, if you have `.tflint.d/policies` locally, it will take precedence over `~/.tflint.d/policies`.

The priority is as follows:

1. `policy_dir` in a config file
2. `TFLINT_OPA_POLICY_DIR` environment variable
3. Current directory (`./.tflint.d/policies`)
4. Home directory (`~/.tflint.d/policies`)