### PR TITLE
Add support for labeled blocks

### DIFF
--- a/opa/conversion.go
+++ b/opa/conversion.go
@@ -111,14 +111,13 @@ func jsonToOption(in map[string]string) (*option, error) {
 	return out, nil
 }
 
-// resource (object<type: string, name: string, config: body, decl_range: range, type_range: range>) representation of "resource" blocks
+// resource (object<type: string, name: string, config: body, decl_range: range>) representation of "resource" blocks
 var resourceTy = types.Named("resource", types.NewObject(
 	[]*types.StaticProperty{
 		types.NewStaticProperty("type", types.S),
 		types.NewStaticProperty("name", types.S),
 		types.NewStaticProperty("config", bodyTy),
 		types.NewStaticProperty("decl_range", rangeTy),
-		types.NewStaticProperty("type_range", rangeTy),
 	},
 	nil,
 )).Description(`representation of "resource" blocks`)
@@ -137,7 +136,6 @@ func resourcesToJSON(resources hclext.Blocks, tyMap map[string]cty.Type, path st
 			"name":       block.Labels[1],
 			"config":     body,
 			"decl_range": rangeToJSON(block.DefRange),
-			"type_range": rangeToJSON(block.LabelRanges[0]),
 		}
 	}
 	return ret, nil


### PR DESCRIPTION
This PR adds support for labeled blocks. Previously, the schema for `terraform.resources` intentionally did not take labeled blocks into account. This is because labeled blocks are not a common use case. See also https://github.com/hashicorp/terraform/issues/32180#issuecomment-1305984280

However, some reserved blocks (e.g. `dynamic`, `backend`) are labeled. The current mechanism cannot retrieve them, so a custom function must explicitly decode them.

To avoid this, we introduce the special keyword `__labels`. You can retrieve labeled blocks by declaring this as a block schema. Below is an example of retrieving dynamic blocks:

```rego
deny_dynamic_blocks[issue] {
  resources := terraform.resources("*", {"dynamic": {"__labels": ["name"]}}, {"expand_mode": "none"})
  dynamic := resources[_].config.dynamic[_]

  issue := tflint.issue("dynamic block is not allowed", dynamic.decl_range)
}
```

At the same time, remove the `type_range` of resources. This is because the purpose is to minimize the schema to maintain as much as possible, and I believe it is not important.