### PR TITLE
Require TFLint >=0.43.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ NOTE: This plugin is working in progress. Not intended for general use.
 
 ## Requirements
 
-- TFLint v0.40+
+- TFLint v0.43+
 - Go v1.19
 
 ## Installation

--- a/main.go
+++ b/main.go
@@ -10,8 +10,9 @@ func main() {
 	plugin.Serve(&plugin.ServeOpts{
 		RuleSet: &opa.RuleSet{
 			BuiltinRuleSet: tflint.BuiltinRuleSet{
-				Name:    "opa",
-				Version: "0.1.0",
+				Name:       "opa",
+				Version:    "0.1.0",
+				Constraint: ">= 0.43.0",
 			},
 		},
 	})


### PR DESCRIPTION
Support for dynamic blocks was added from v0.43, so to avoid confusion, set a constraint to only work with v0.43+.