### PR TITLE
Fix internal marshal error of sensitive value

### DIFF
--- a/opa/conversion.go
+++ b/opa/conversion.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/open-policy-agent/opa/types"
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
+	"github.com/terraform-linters/tflint-plugin-sdk/terraform/lang/marks"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/convert"
@@ -292,6 +293,11 @@ func exprToJSON(expr hcl.Expression, tyMap map[string]cty.Type, path string, run
 			return ret, nil
 		}
 		return ret, err
+	}
+	if marks.Contains(value, marks.Sensitive) {
+		ret["unknown"] = true
+		ret["sensitive"] = true
+		return ret, nil
 	}
 	if !value.IsWhollyKnown() {
 		ret["unknown"] = true

--- a/opa/conversion_test.go
+++ b/opa/conversion_test.go
@@ -583,6 +583,21 @@ func TestExprToJSON(t *testing.T) {
 			source: `variable "foo" { sensitive = true }`,
 		},
 		{
+			name:  "composite sensitive",
+			input: parse("[var.foo]"),
+			ty:    cty.String,
+			want: map[string]any{
+				"unknown":   true,
+				"sensitive": true,
+				"range": map[string]any{
+					"filename": "main.tf",
+					"start":    map[string]int{"line": 1, "column": 1, "byte": 0},
+					"end":      map[string]int{"line": 1, "column": 10, "byte": 9},
+				},
+			},
+			source: `variable "foo" { sensitive = true }`,
+		},
+		{
 			name:  "invalid type",
 			input: hcl.StaticExpr(cty.StringVal("foo"), hcl.Range{Filename: "main.tf", Start: hcl.InitialPos, End: hcl.InitialPos}),
 			ty:    cty.Number,

--- a/opa/test_runner.go
+++ b/opa/test_runner.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/hcl/v2/hclparse"
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
 	"github.com/terraform-linters/tflint-plugin-sdk/terraform/addrs"
+	"github.com/terraform-linters/tflint-plugin-sdk/terraform/lang/marks"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/gocty"
@@ -97,7 +98,7 @@ func (r *testRunner) GetModuleContent(schema *hclext.BodySchema, _ *tflint.GetMo
 	return content, nil
 }
 
-var sensitiveMark = cty.NewValueMarks("sensitive")
+var sensitiveMark = cty.NewValueMarks(marks.Sensitive)
 
 // EvaluateExpr returns a value of the passed expression.
 // Not expected to reflect anything other than cty.Value.
@@ -123,9 +124,6 @@ func (r *testRunner) EvaluateExpr(expr hcl.Expression, ret interface{}, _ *tflin
 	})
 	if diags.HasErrors() {
 		return diags
-	}
-	if val.IsMarked() {
-		return tflint.ErrSensitive
 	}
 
 	return gocty.FromCtyValue(val, ret)

--- a/opa/test_runner_test.go
+++ b/opa/test_runner_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
-	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -236,7 +235,7 @@ variable "instance_type" {
 	sensitive = true
 }`,
 			expr: parse("var.instance_type"),
-			err:  tflint.ErrSensitive,
+			want: `cty.StringVal("t2.micro").Mark(marks.Sensitive)`,
 		},
 	}
 


### PR DESCRIPTION
See https://github.com/terraform-linters/tflint-ruleset-opa/actions/runs/4651361434/jobs/8230916678
See https://github.com/terraform-linters/tflint-plugin-sdk/pull/239

TFLint v0.46 now allows marked values (sensitive values) to be transferred to plugins. In that case, evaluating a sensitive value will not return `tflint.ErrSensitive`, but rather the marked `cty.Value`.

`exprToJSON` tries to marshal `cty.Value` to JSON format, but it returns an error like the below when marshaling a marked value:

```
value has marks, so it cannot be serialized as JSON
```

This PR converts marked values to JSON in a different way to prevent this error.