### PR TITLE
docs: Clarify what `policy_dir` is relative to

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,3 +22,5 @@ Change the directory from which policies are loaded. The priority is as follows:
 2. `TFLINT_OPA_POLICY_DIR` environment variable
 3. `./.tflint.d/policies`
 4. `~/.tflint.d/policies`
+
+A relative path is resolved from the current directory.


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint-ruleset-opa/issues/43