### PR TITLE
Add `terraform.imports` and `terraform.checks` functions

### DIFF
--- a/docs/functions.md
+++ b/docs/functions.md
@@ -566,6 +566,52 @@ terraform.moved_blocks({"from": "any"}, {})
 ]
 ```
 
+## `terraform.imports`
+
+```rego
+blocks := terraform.imports(schema, options)
+```
+
+Returns Terraform imports blocks.
+
+- `schema` (schema): schema for attributes referenced in rules.
+- `options` (object[string: string]): options to change the retrieve/evaluate behavior.
+
+Returns:
+
+- `blocks` (array[object<config: body, decl_range: range>]): Terraform "import" blocks.
+
+The `schema` and `options` are equivalent to the arguments of the `terraform.resources` function.
+
+Examples:
+
+```hcl
+import {
+  to = aws_instance.example
+  id = "i-abcd1234"
+}
+```
+
+```rego
+terraform.imports({"id": "string"}, {})
+```
+
+```json
+[
+  {
+    "config": {
+      "id": {
+        "value": "i-abcd1234",
+        "unknown": false,
+        "sensitive": false,
+        "range": {...}
+      }
+    },
+    "decl_range": {...}
+  }
+]
+```
+
 ## `terraform.module_range`
 
 ```rego

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -612,6 +612,65 @@ terraform.imports({"id": "string"}, {})
 ]
 ```
 
+## `terraform.checks`
+
+```rego
+blocks := terraform.checks(schema, options)
+```
+
+Returns Terraform check blocks.
+
+- `schema` (schema): schema for attributes referenced in rules.
+- `options` (object[string: string]): options to change the retrieve/evaluate behavior.
+
+Returns:
+
+- `blocks` (array[object<config: body, decl_range: range>]): Terraform "check" blocks.
+
+The `schema` and `options` are equivalent to the arguments of the `terraform.resources` function.
+
+Examples:
+
+```hcl
+check "health_check" {
+  data "http" "terraform_io" {
+    url = "https://www.terraform.io"
+  }
+
+  assert {
+    condition = data.http.terraform_io.status_code == 200
+    error_message = "${data.http.terraform_io.url} returned an unhealthy status code"
+  }
+}
+```
+
+```rego
+terraform.checks({"assert": {"condition": "bool"}}, {})
+```
+
+```json
+[
+  {
+    "config": {
+      "assert": [
+        {
+          "config": {
+            "condition": {
+              "unknown": true,
+              "sensitive": false,
+              "range": {...}
+            }
+          },
+          "labels": null,
+          "decl_range": {...}
+        }
+      ]
+    },
+    "decl_range": {...}
+  }
+]
+```
+
 ## `terraform.module_range`
 
 ```rego

--- a/integration/checks/.tflint.hcl
+++ b/integration/checks/.tflint.hcl
@@ -1,0 +1,9 @@
+plugin "terraform" {
+  enabled = false
+}
+
+plugin "opa" {
+  enabled = true
+
+  policy_dir = "policies"
+}

--- a/integration/checks/main.tf
+++ b/integration/checks/main.tf
@@ -1,0 +1,17 @@
+check "health_check" {
+  data "http" "terraform_io" {
+    url = "https://www.terraform.io"
+  }
+
+  assert {
+    condition = data.http.terraform_io.status_code == 200
+    error_message = "${data.http.terraform_io.url} returned an unhealthy status code"
+  }
+}
+
+check "deterministic" {
+  assert {
+    condition = 200 == 200
+    error_message = "condition should be true"
+  }
+}

--- a/integration/checks/policies/main.rego
+++ b/integration/checks/policies/main.rego
@@ -1,0 +1,9 @@
+package tflint
+
+deny_deterministic_check_condition[issue] {
+  checks := terraform.checks({"assert": {"condition": "bool"}}, {})
+  condition = checks[_].config.assert[_].config.condition
+  condition.unknown == false
+
+  issue := tflint.issue("deterministic check condtion is not allowed", condition.range)
+}

--- a/integration/checks/policies/main_test.rego
+++ b/integration/checks/policies/main_test.rego
@@ -1,0 +1,24 @@
+package tflint
+import future.keywords
+
+mock_checks(schema, options) := terraform.mock_checks(schema, options, {"main.tf": `
+check "deterministic" {
+  assert {
+    condition = 200 == 200
+    error_message = "condition should be true"
+  }
+}`})
+
+test_deny_deterministic_check_condition_passed if {
+  issues := deny_deterministic_check_condition with terraform.checks as mock_checks
+
+  count(issues) == 1
+  issue := issues[_]
+  issue.msg == "deterministic check condtion is not allowed"
+}
+
+test_deny_deterministic_check_condition_failed if {
+  issues := deny_deterministic_check_condition with terraform.checks as mock_checks
+
+  count(issues) == 0
+}

--- a/integration/checks/result.json
+++ b/integration/checks/result.json
@@ -1,0 +1,25 @@
+{
+  "issues": [
+    {
+      "rule": {
+        "name": "opa_deny_deterministic_check_condition",
+        "severity": "error",
+        "link": "policies/main.rego:3"
+      },
+      "message": "deterministic check condtion is not allowed",
+      "range": {
+        "filename": "main.tf",
+        "start": {
+          "line": 14,
+          "column": 17
+        },
+        "end": {
+          "line": 14,
+          "column": 27
+        }
+      },
+      "callers": []
+    }
+  ],
+  "errors": []
+}

--- a/integration/checks/result_test.json
+++ b/integration/checks/result_test.json
@@ -1,0 +1,25 @@
+{
+  "issues": [
+    {
+      "rule": {
+        "name": "opa_test_deny_deterministic_check_condition_failed",
+        "severity": "error",
+        "link": "policies/main_test.rego:20"
+      },
+      "message": "test failed",
+      "range": {
+        "filename": "",
+        "start": {
+          "line": 0,
+          "column": 0
+        },
+        "end": {
+          "line": 0,
+          "column": 0
+        }
+      },
+      "callers": []
+    }
+  ],
+  "errors": []
+}

--- a/integration/imports/.tflint.hcl
+++ b/integration/imports/.tflint.hcl
@@ -1,0 +1,9 @@
+plugin "terraform" {
+  enabled = false
+}
+
+plugin "opa" {
+  enabled = true
+
+  policy_dir = "policies"
+}

--- a/integration/imports/main.tf
+++ b/integration/imports/main.tf
@@ -1,0 +1,4 @@
+import {
+  to = aws_instance.example
+  id = "i-abcd1234"
+}

--- a/integration/imports/policies/main.rego
+++ b/integration/imports/policies/main.rego
@@ -1,0 +1,8 @@
+package tflint
+
+deny_import_blocks[issue] {
+  imports := terraform.imports({}, {})
+  count(imports) > 0
+
+  issue := tflint.issue("import blocks are not allowed", imports[0].decl_range)
+}

--- a/integration/imports/policies/main_test.rego
+++ b/integration/imports/policies/main_test.rego
@@ -1,0 +1,22 @@
+package tflint
+import future.keywords
+
+mock_imports(schema, options) := terraform.mock_imports(schema, options, {"main.tf": `
+import {
+  to = aws_instance.example
+  id = "i-abcd1234"
+}`})
+
+test_deny_import_blocks_passed if {
+  issues := deny_import_blocks with terraform.imports as mock_imports
+
+  count(issues) == 1
+  issue := issues[_]
+  issue.msg == "import blocks are not allowed"
+}
+
+test_deny_import_blocks_failed if {
+  issues := deny_import_blocks with terraform.imports as mock_imports
+
+  count(issues) == 0
+}

--- a/integration/imports/result.json
+++ b/integration/imports/result.json
@@ -1,0 +1,25 @@
+{
+  "issues": [
+    {
+      "rule": {
+        "name": "opa_deny_import_blocks",
+        "severity": "error",
+        "link": "policies/main.rego:3"
+      },
+      "message": "import blocks are not allowed",
+      "range": {
+        "filename": "main.tf",
+        "start": {
+          "line": 1,
+          "column": 1
+        },
+        "end": {
+          "line": 1,
+          "column": 7
+        }
+      },
+      "callers": []
+    }
+  ],
+  "errors": []
+}

--- a/integration/imports/result_test.json
+++ b/integration/imports/result_test.json
@@ -1,0 +1,25 @@
+{
+  "issues": [
+    {
+      "rule": {
+        "name": "opa_test_deny_import_blocks_failed",
+        "severity": "error",
+        "link": "policies/main_test.rego:18"
+      },
+      "message": "test failed",
+      "range": {
+        "filename": "",
+        "start": {
+          "line": 0,
+          "column": 0
+        },
+        "end": {
+          "line": 0,
+          "column": 0
+        }
+      },
+      "callers": []
+    }
+  ],
+  "errors": []
+}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -214,6 +214,17 @@ func TestIntegration(t *testing.T) {
 			dir:     "imports",
 			test:    true,
 		},
+		{
+			name:    "checks",
+			command: exec.Command("tflint", "--format", "json", "--force"),
+			dir:     "checks",
+		},
+		{
+			name:    "checks (test)",
+			command: exec.Command("tflint", "--format", "json", "--force"),
+			dir:     "checks",
+			test:    true,
+		},
 	}
 
 	dir, _ := os.Getwd()

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -203,6 +203,17 @@ func TestIntegration(t *testing.T) {
 			dir:     "moved",
 			test:    true,
 		},
+		{
+			name:    "imports",
+			command: exec.Command("tflint", "--format", "json", "--force"),
+			dir:     "imports",
+		},
+		{
+			name:    "imports (test)",
+			command: exec.Command("tflint", "--format", "json", "--force"),
+			dir:     "imports",
+			test:    true,
+		},
 	}
 
 	dir, _ := os.Getwd()

--- a/opa/functions.go
+++ b/opa/functions.go
@@ -28,6 +28,7 @@ func Functions(runner tflint.Runner) []func(*rego.Rego) {
 		localsFunc(runner).asOption(),
 		movedBlocksFunc(runner).asOption(),
 		importsFunc(runner).asOption(),
+		checksFunc(runner).asOption(),
 		moduleRangeFunc(runner).asOption(),
 		issueFunc().asOption(),
 	}
@@ -46,6 +47,7 @@ func TesterFunctions(runner tflint.Runner) []*tester.Builtin {
 		localsFunc(runner).asTester(),
 		movedBlocksFunc(runner).asTester(),
 		importsFunc(runner).asTester(),
+		checksFunc(runner).asTester(),
 		moduleRangeFunc(runner).asTester(),
 		issueFunc().asTester(),
 	}
@@ -66,6 +68,7 @@ func MockFunctions() []func(*rego.Rego) {
 		mockFunction1(localsFunc).asOption(),
 		mockFunction2(movedBlocksFunc).asOption(),
 		mockFunction2(importsFunc).asOption(),
+		mockFunction2(checksFunc).asOption(),
 	}
 }
 
@@ -82,6 +85,7 @@ func TesterMockFunctions() []*tester.Builtin {
 		mockFunction1(localsFunc).asTester(),
 		mockFunction2(movedBlocksFunc).asTester(),
 		mockFunction2(importsFunc).asTester(),
+		mockFunction2(checksFunc).asTester(),
 	}
 }
 
@@ -419,6 +423,35 @@ func importsFunc(runner tflint.Runner) *function2 {
 		},
 		Func: func(_ rego.BuiltinContext, schema *ast.Term, options *ast.Term) (*ast.Term, error) {
 			return blockFunc(schema, options, "import", runner)
+		},
+	}
+}
+
+// terraform.checks: blocks := terraform.checks(schema, options)
+//
+// Returns Terraform check blocks.
+//
+//	schema  (schema)  schema for attributes referenced in rules.
+//	options (options) options to change the retrieve/evaluate behavior.
+//
+// Returns:
+//
+//	blocks (array[block]) Terraform "check" blocks
+func checksFunc(runner tflint.Runner) *function2 {
+	return &function2{
+		function: function{
+			Decl: &rego.Function{
+				Name: "terraform.checks",
+				Decl: types.NewFunction(
+					types.Args(schemaTy, optionsTy),
+					types.NewArray(nil, blockTy),
+				),
+				Memoize:          true,
+				Nondeterministic: true,
+			},
+		},
+		Func: func(_ rego.BuiltinContext, schema *ast.Term, options *ast.Term) (*ast.Term, error) {
+			return namedBlockFunc(schema, options, "check", runner)
 		},
 	}
 }

--- a/opa/functions.go
+++ b/opa/functions.go
@@ -27,6 +27,7 @@ func Functions(runner tflint.Runner) []func(*rego.Rego) {
 		outputsFunc(runner).asOption(),
 		localsFunc(runner).asOption(),
 		movedBlocksFunc(runner).asOption(),
+		importsFunc(runner).asOption(),
 		moduleRangeFunc(runner).asOption(),
 		issueFunc().asOption(),
 	}
@@ -44,6 +45,7 @@ func TesterFunctions(runner tflint.Runner) []*tester.Builtin {
 		outputsFunc(runner).asTester(),
 		localsFunc(runner).asTester(),
 		movedBlocksFunc(runner).asTester(),
+		importsFunc(runner).asTester(),
 		moduleRangeFunc(runner).asTester(),
 		issueFunc().asTester(),
 	}
@@ -63,6 +65,7 @@ func MockFunctions() []func(*rego.Rego) {
 		mockFunction2(outputsFunc).asOption(),
 		mockFunction1(localsFunc).asOption(),
 		mockFunction2(movedBlocksFunc).asOption(),
+		mockFunction2(importsFunc).asOption(),
 	}
 }
 
@@ -78,6 +81,7 @@ func TesterMockFunctions() []*tester.Builtin {
 		mockFunction2(outputsFunc).asTester(),
 		mockFunction1(localsFunc).asTester(),
 		mockFunction2(movedBlocksFunc).asTester(),
+		mockFunction2(importsFunc).asTester(),
 	}
 }
 
@@ -386,6 +390,35 @@ func movedBlocksFunc(runner tflint.Runner) *function2 {
 		},
 		Func: func(_ rego.BuiltinContext, schema *ast.Term, options *ast.Term) (*ast.Term, error) {
 			return blockFunc(schema, options, "moved", runner)
+		},
+	}
+}
+
+// terraform.imports: blocks := terraform.imports(schema, options)
+//
+// Returns Terraform import blocks.
+//
+//	schema  (schema)  schema for attributes referenced in rules.
+//	options (options) options to change the retrieve/evaluate behavior.
+//
+// Returns:
+//
+//	blocks (array[block]) Terraform "import" blocks
+func importsFunc(runner tflint.Runner) *function2 {
+	return &function2{
+		function: function{
+			Decl: &rego.Function{
+				Name: "terraform.imports",
+				Decl: types.NewFunction(
+					types.Args(schemaTy, optionsTy),
+					types.NewArray(nil, blockTy),
+				),
+				Memoize:          true,
+				Nondeterministic: true,
+			},
+		},
+		Func: func(_ rego.BuiltinContext, schema *ast.Term, options *ast.Term) (*ast.Term, error) {
+			return blockFunc(schema, options, "import", runner)
 		},
 	}
 }

--- a/opa/functions_test.go
+++ b/opa/functions_test.go
@@ -1143,6 +1143,109 @@ variable "foo" {}`,
 	}
 }
 
+func TestImportsFunc(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  string
+		schema  map[string]any
+		options map[string]string
+		want    []map[string]any
+	}{
+		{
+			name: "imports",
+			config: `
+import {
+	to = aws_instance.example
+	id = "i-abcd1234"
+}`,
+			schema: map[string]any{"id": "string"},
+			want: []map[string]any{
+				{
+					"config": map[string]any{
+						"id": map[string]any{
+							"value":     "i-abcd1234",
+							"unknown":   false,
+							"sensitive": false,
+							"range": map[string]any{
+								"filename": "main.tf",
+								"start": map[string]int{
+									"line":   4,
+									"column": 7,
+									"byte":   43,
+								},
+								"end": map[string]int{
+									"line":   4,
+									"column": 19,
+									"byte":   55,
+								},
+							},
+						},
+					},
+					"decl_range": map[string]any{
+						"filename": "main.tf",
+						"start": map[string]int{
+							"line":   2,
+							"column": 1,
+							"byte":   1,
+						},
+						"end": map[string]int{
+							"line":   2,
+							"column": 7,
+							"byte":   7,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			schema, err := ast.InterfaceToValue(test.schema)
+			if err != nil {
+				t.Fatal(err)
+			}
+			options, err := ast.InterfaceToValue(test.options)
+			if err != nil {
+				t.Fatal(err)
+			}
+			config, err := ast.InterfaceToValue(map[string]string{"main.tf": test.config})
+			if err != nil {
+				t.Fatal(err)
+			}
+			want, err := ast.InterfaceToValue(test.want)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			runner, diags := NewTestRunner(map[string]string{"main.tf": test.config})
+			if diags.HasErrors() {
+				t.Fatal(diags)
+			}
+
+			ctx := rego.BuiltinContext{}
+			got, err := importsFunc(runner).Func(ctx, ast.NewTerm(schema), ast.NewTerm(options))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(want.String(), got.Value.String()); diff != "" {
+				t.Error(diff)
+			}
+
+			ctx = rego.BuiltinContext{}
+			got, err = mockFunction2(importsFunc).Func(ctx, ast.NewTerm(schema), ast.NewTerm(options), ast.NewTerm(config))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(want.String(), got.Value.String()); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}
+
 func TestModuleRangeFunc(t *testing.T) {
 	tests := []struct {
 		name   string


### PR DESCRIPTION
See https://developer.hashicorp.com/terraform/language/import
See https://developer.hashicorp.com/terraform/language/checks

This PR adds new functions, `terraform.imports` and `terraform.checks`. These correspond to the `import` and `check` blocks introduced in Terraform v1.5.

The function interface and return values are pretty much the same as other functions, so there's no new functionality.