### PR TITLE
Fix E2E tests failing with TFLint v0.50

### DIFF
--- a/integration/resources/main.tf
+++ b/integration/resources/main.tf
@@ -1,1 +1,1 @@
-module "aws_instance" {}
+variable "instance_type" {}


### PR DESCRIPTION
See https://github.com/terraform-linters/tflint-ruleset-opa/actions/runs/7333894624/job/19969932237#step:7:59

TFLint v0.50 now automatically loads local modules, which causes some tests to fail. This PR fixes the E2E test resources to avoid these issues.