### PR TITLE
Add `terraform.removed_blocks` function

### DIFF
--- a/docs/functions.md
+++ b/docs/functions.md
@@ -671,6 +671,54 @@ terraform.checks({"assert": {"condition": "bool"}}, {})
 ]
 ```
 
+## `terraform.removed_blocks`
+
+```rego
+blocks := terraform.removed_blocks(schema, options)
+```
+
+Returns Terraform removed blocks.
+
+- `schema` (schema): schema for attributes referenced in rules.
+- `options` (object[string: string]): options to change the retrieve/evaluate behavior.
+
+Returns:
+
+- `blocks` (array[object<config: body, decl_range: range>]): Terraform "removed" blocks.
+
+The `schema` and `options` are equivalent to the arguments of the `terraform.resources` function.
+
+Examples:
+
+```hcl
+removed {
+  from = aws_instance.example
+
+  lifecycle {
+    destroy = false
+  }
+}
+```
+
+```rego
+terraform.removed_blocks({"from": "any"}, {})
+```
+
+```json
+[
+  {
+    "config": {
+      "from": {
+        "unknown": true,
+        "sensitive": false,
+        "range": {...}
+      }
+    },
+    "decl_range": {...}
+  }
+]
+```
+
 ## `terraform.module_range`
 
 ```rego

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -225,6 +225,17 @@ func TestIntegration(t *testing.T) {
 			dir:     "checks",
 			test:    true,
 		},
+		{
+			name:    "removed blocks",
+			command: exec.Command("tflint", "--format", "json", "--force"),
+			dir:     "removed",
+		},
+		{
+			name:    "removed blocks (test)",
+			command: exec.Command("tflint", "--format", "json", "--force"),
+			dir:     "removed",
+			test:    true,
+		},
 	}
 
 	dir, _ := os.Getwd()

--- a/integration/removed/.tflint.hcl
+++ b/integration/removed/.tflint.hcl
@@ -1,0 +1,9 @@
+plugin "terraform" {
+  enabled = false
+}
+
+plugin "opa" {
+  enabled = true
+
+  policy_dir = "policies"
+}

--- a/integration/removed/main.tf
+++ b/integration/removed/main.tf
@@ -1,0 +1,7 @@
+removed {
+  from = aws_instance.example
+
+  lifecycle {
+    destroy = false
+  }
+}

--- a/integration/removed/policies/main.rego
+++ b/integration/removed/policies/main.rego
@@ -1,0 +1,8 @@
+package tflint
+
+deny_removed_blocks[issue] {
+  moved := terraform.removed_blocks({}, {})
+  count(moved) > 0
+
+  issue := tflint.issue("removed blocks are not allowed", moved[0].decl_range)
+}

--- a/integration/removed/policies/main_test.rego
+++ b/integration/removed/policies/main_test.rego
@@ -1,0 +1,25 @@
+package tflint
+import future.keywords
+
+mock_removed_blocks(schema, options) := terraform.mock_removed_blocks(schema, options, {"main.tf": `
+removed {
+  from = aws_instance.example
+
+  lifecycle {
+    destroy = false
+  }
+}`})
+
+test_deny_removed_blocks_passed if {
+  issues := deny_removed_blocks with terraform.removed_blocks as mock_removed_blocks
+
+  count(issues) == 1
+  issue := issues[_]
+  issue.msg == "removed blocks are not allowed"
+}
+
+test_deny_removed_blocks_failed if {
+  issues := deny_removed_blocks with terraform.removed_blocks as mock_removed_blocks
+
+  count(issues) == 0
+}

--- a/integration/removed/result.json
+++ b/integration/removed/result.json
@@ -1,0 +1,25 @@
+{
+  "issues": [
+    {
+      "rule": {
+        "name": "opa_deny_removed_blocks",
+        "severity": "error",
+        "link": "policies/main.rego:3"
+      },
+      "message": "removed blocks are not allowed",
+      "range": {
+        "filename": "main.tf",
+        "start": {
+          "line": 1,
+          "column": 1
+        },
+        "end": {
+          "line": 1,
+          "column": 8
+        }
+      },
+      "callers": []
+    }
+  ],
+  "errors": []
+}

--- a/integration/removed/result_test.json
+++ b/integration/removed/result_test.json
@@ -1,0 +1,25 @@
+{
+  "issues": [
+    {
+      "rule": {
+        "name": "opa_test_deny_removed_blocks_failed",
+        "severity": "error",
+        "link": "policies/main_test.rego:21"
+      },
+      "message": "test failed",
+      "range": {
+        "filename": "",
+        "start": {
+          "line": 0,
+          "column": 0
+        },
+        "end": {
+          "line": 0,
+          "column": 0
+        }
+      },
+      "callers": []
+    }
+  ],
+  "errors": []
+}

--- a/opa/functions.go
+++ b/opa/functions.go
@@ -29,6 +29,7 @@ func Functions(runner tflint.Runner) []func(*rego.Rego) {
 		movedBlocksFunc(runner).asOption(),
 		importsFunc(runner).asOption(),
 		checksFunc(runner).asOption(),
+		removedBlocksFunc(runner).asOption(),
 		moduleRangeFunc(runner).asOption(),
 		issueFunc().asOption(),
 	}
@@ -48,6 +49,7 @@ func TesterFunctions(runner tflint.Runner) []*tester.Builtin {
 		movedBlocksFunc(runner).asTester(),
 		importsFunc(runner).asTester(),
 		checksFunc(runner).asTester(),
+		removedBlocksFunc(runner).asTester(),
 		moduleRangeFunc(runner).asTester(),
 		issueFunc().asTester(),
 	}
@@ -69,6 +71,7 @@ func MockFunctions() []func(*rego.Rego) {
 		mockFunction2(movedBlocksFunc).asOption(),
 		mockFunction2(importsFunc).asOption(),
 		mockFunction2(checksFunc).asOption(),
+		mockFunction2(removedBlocksFunc).asOption(),
 	}
 }
 
@@ -86,6 +89,7 @@ func TesterMockFunctions() []*tester.Builtin {
 		mockFunction2(movedBlocksFunc).asTester(),
 		mockFunction2(importsFunc).asTester(),
 		mockFunction2(checksFunc).asTester(),
+		mockFunction2(removedBlocksFunc).asTester(),
 	}
 }
 
@@ -525,6 +529,35 @@ func checksFunc(runner tflint.Runner) *function2 {
 		},
 		Func: func(_ rego.BuiltinContext, schema *ast.Term, options *ast.Term) (*ast.Term, error) {
 			return namedBlockFunc(schema, options, "check", runner)
+		},
+	}
+}
+
+// terraform.removed_blocks: blocks := terraform.removed_blocks(schema, options)
+//
+// Returns Terraform removed blocks.
+//
+//	schema  (schema)  schema for attributes referenced in rules.
+//	options (options) options to change the retrieve/evaluate behavior.
+//
+// Returns:
+//
+//	blocks (array[block]) Terraform "removed" blocks
+func removedBlocksFunc(runner tflint.Runner) *function2 {
+	return &function2{
+		function: function{
+			Decl: &rego.Function{
+				Name: "terraform.removed_blocks",
+				Decl: types.NewFunction(
+					types.Args(schemaTy, optionsTy),
+					types.NewArray(nil, blockTy),
+				),
+				Memoize:          true,
+				Nondeterministic: true,
+			},
+		},
+		Func: func(_ rego.BuiltinContext, schema *ast.Term, options *ast.Term) (*ast.Term, error) {
+			return blockFunc(schema, options, "removed", runner)
 		},
 	}
 }


### PR DESCRIPTION
See https://developer.hashicorp.com/terraform/language/resources/syntax#removing-resources

This PR adds a new `terraform.removed_blocks` function. This correspond to the `removed` blocks introduced in Terraform v1.7.
The function interface and return values are pretty much the same as other functions, so there's no new functionality.