### PR TITLE
Rewrite policies with `import rego.v1`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,14 @@ For example, your organization wants to enforce S3 bucket names to always start 
 ```rego
 package tflint
 
-deny_invalid_s3_bucket_name[issue] {
-  buckets := terraform.resources("aws_s3_bucket", {"bucket": "string"}, {})
-  name := buckets[_].config.bucket
-  not startswith(name.value, "example-com-")
+import rego.v1
 
-  issue := tflint.issue(`Bucket names should always start with "example-com-"`, name.range)
+deny_invalid_s3_bucket_name contains issue if {
+	buckets := terraform.resources("aws_s3_bucket", {"bucket": "string"}, {})
+	name := buckets[_].config.bucket
+	not startswith(name.value, "example-com-")
+
+	issue := tflint.issue(`Bucket names should always start with "example-com-"`, name.range)
 }
 ```
 
@@ -71,7 +73,7 @@ Error: Bucket names should always start with "example-com-" (opa_deny_invalid_s3
   on main.tf line 2:
    2:   bucket = "example-corp-assets"
 
-Reference: .tflint.d/policies/bucket.rego:3
+Reference: .tflint.d/policies/bucket.rego:5
 
 ```
 

--- a/docs/debug.md
+++ b/docs/debug.md
@@ -15,12 +15,14 @@ resource "aws_instance" "main" {
 ```rego
 package tflint
 
-deny_invalid_instance_type[issue] {
-  instances := terraform.resources("aws_instance", {"instance_type": "string"}, {})
-  print(instances)
-  instances[_].config.type.value == "t2.micro" # typo: type -> instance_type
+import rego.v1
 
-  issue := tflint.issue("t2.micro is not allowed", instances[_].config.instance_type.range)
+deny_invalid_instance_type contains issue if {
+	instances := terraform.resources("aws_instance", {"instance_type": "string"}, {})
+	print(instances)
+	instances[_].config.type.value == "t2.micro" # typo: type -> instance_type
+
+	issue := tflint.issue("t2.micro is not allowed", instances[_].config.instance_type.range)
 }
 ```
 
@@ -39,12 +41,14 @@ The `trace` function prints a `note` to the trace. Tracing can be enabled by set
 ```rego
 package tflint
 
-deny_invalid_instance_type[issue] {
-  instances := terraform.resources("aws_instance", {"instance_type": "string"}, {})
-  trace("after fetch")
-  instances[_].config.type.value == "t2.micro"
+import rego.v1
 
-  issue := tflint.issue("t2.micro is not allowed", instances[_].config.instance_type.range)
+deny_invalid_instance_type contains issue if {
+	instances := terraform.resources("aws_instance", {"instance_type": "string"}, {})
+	trace("after fetch")
+	instances[_].config.type.value == "t2.micro"
+
+	issue := tflint.issue("t2.micro is not allowed", instances[_].config.instance_type.range)
 }
 ```
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -9,12 +9,14 @@ As an example, create the following policy as `.tflint.d/policies/bucket.rego`:
 ```rego
 package tflint
 
-deny_invalid_s3_bucket_name[issue] {
-  buckets := terraform.resources("aws_s3_bucket", {"bucket": "string"}, {})
-  name := buckets[_].config.bucket
-  not startswith(name.value, "example-com-")
+import rego.v1
 
-  issue := tflint.issue(`Bucket names should always start with "example-com-"`, name.range)
+deny_invalid_s3_bucket_name contains issue if {
+	buckets := terraform.resources("aws_s3_bucket", {"bucket": "string"}, {})
+	name := buckets[_].config.bucket
+	not startswith(name.value, "example-com-")
+
+	issue := tflint.issue(`Bucket names should always start with "example-com-"`, name.range)
 }
 ```
 
@@ -39,7 +41,13 @@ package tflint
 The first line is the package declaration. All valid policies must be described under the `tflint` package.
 
 ```rego
-deny_invalid_s3_bucket_name[issue] {
+import rego.v1
+```
+
+This declaration ensures compatibility with future OPA v1 syntax. See [The `rego.v1` Import](https://www.openpolicyagent.org/docs/latest/policy-language/#the-regov1-import) for details.
+
+```rego
+deny_invalid_s3_bucket_name contains issue if {
 ```
 
 The next line is the rule declaration. A valid rule name must start with `deny_`, `violation_`, `warn_` or `notice_`. The rule name in TFLint is the rule name with "opa_" prefix (e.g. `opa_deny_invalid_s3_bucket_name`), and the severity is error for `deny_` or `violation_`, warning for `warn_`, and notice for `notice_`.
@@ -129,7 +137,7 @@ Error: Bucket names should always start with "example-com-" (opa_deny_invalid_s3
   on main.tf line 2:
    2:   bucket = "example-corp-assets"
 
-Reference: .tflint.d/policies/main.rego:3
+Reference: .tflint.d/policies/main.rego:5
 
 ```
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -7,39 +7,44 @@ Below is an example that tests a policy that enforces a bucket name:
 ```rego
 package tflint
 
-deny_invalid_s3_bucket_name[issue] {
-  buckets := terraform.resources("aws_s3_bucket", {"bucket": "string"}, {})
-  name := buckets[_].config.bucket
-  not startswith(name.value, "example-com-")
+import rego.v1
 
-  issue := tflint.issue(`Bucket names should always start with "example-com-"`, name.range)
+deny_invalid_s3_bucket_name contains issue if {
+	buckets := terraform.resources("aws_s3_bucket", {"bucket": "string"}, {})
+	name := buckets[_].config.bucket
+	not startswith(name.value, "example-com-")
+
+	issue := tflint.issue(`Bucket names should always start with "example-com-"`, name.range)
 }
 ```
 
 ```rego
 package tflint
-import future.keywords.if
+
+import rego.v1
 
 failed_resources(type, schema, options) := terraform.mock_resources(type, schema, options, {"main.tf": `
 resource "aws_s3_bucket" "invalid" {
   bucket = "example-corp-assets"
 }`})
-test_deny_invalid_s3_bucket_name_failed if {
-  issues := deny_invalid_s3_bucket_name with terraform.resources as failed_resources
 
-  count(issues) == 1
-  issue := issues[_]
-  issue.msg == `Bucket names should always start with "example-com-"`
+test_deny_invalid_s3_bucket_name_failed if {
+	issues := deny_invalid_s3_bucket_name with terraform.resources as failed_resources
+
+	count(issues) == 1
+	issue := issues[_]
+	issue.msg == `Bucket names should always start with "example-com-"`
 }
 
 passed_resources(type, schema, options) := terraform.mock_resources(type, schema, options, {"main.tf": `
 resource "aws_s3_bucket" "valid" {
   bucket = "example-com-assets"
 }`})
-test_deny_invalid_s3_bucket_name_passed if {
-  issues := deny_invalid_s3_bucket_name with terraform.resources as passed_resources
 
-  count(issues) == 0
+test_deny_invalid_s3_bucket_name_passed if {
+	issues := deny_invalid_s3_bucket_name with terraform.resources as passed_resources
+
+	count(issues) == 0
 }
 ```
 
@@ -61,6 +66,6 @@ Error: test failed (opa_test_deny_invalid_s3_bucket_name_failed)
   on  line 0:
    (source code not available)
 
-Reference: .tflint.d/policies/bucket_test.rego:8
+Reference: .tflint.d/policies/bucket_test.rego:10
 
 ```

--- a/examples/enforce_bucket_names/.tflint.d/policies/bucket.rego
+++ b/examples/enforce_bucket_names/.tflint.d/policies/bucket.rego
@@ -1,23 +1,24 @@
 package tflint
-import future.keywords.contains
-import future.keywords.if
+
+import rego.v1
 
 # Set `expand_mode: none` to check names even if they are not created
 s3_buckets := terraform.resources("aws_s3_bucket", {"bucket": "string"}, {"expand_mode": "none"})
 
 s3_bucket_names contains name if {
-  name := s3_buckets[_].config.bucket
+	name := s3_buckets[_].config.bucket
 }
 
 # Rules for unknown values
-deny_invalid_s3_bucket_name[issue] {
-  s3_bucket_names[i].unknown
+deny_invalid_s3_bucket_name contains issue if {
+	s3_bucket_names[i].unknown
 
-  issue := tflint.issue("Dynamic value is not allowed in bucket", s3_bucket_names[i].range)
+	issue := tflint.issue("Dynamic value is not allowed in bucket", s3_bucket_names[i].range)
 }
-# Rules for invalid names
-deny_invalid_s3_bucket_name[issue] {
-  not startswith(s3_bucket_names[i].value, "example-com-")
 
-  issue := tflint.issue(`Bucket names should always start with "example-com-"`, s3_bucket_names[i].range)
+# Rules for invalid names
+deny_invalid_s3_bucket_name contains issue if {
+	not startswith(s3_bucket_names[i].value, "example-com-")
+
+	issue := tflint.issue(`Bucket names should always start with "example-com-"`, s3_bucket_names[i].range)
 }

--- a/examples/enforce_bucket_names/.tflint.d/policies/bucket_test.rego
+++ b/examples/enforce_bucket_names/.tflint.d/policies/bucket_test.rego
@@ -1,26 +1,29 @@
 package tflint
-import future.keywords.if
+
+import rego.v1
 
 failed_resources(type, schema, options) := terraform.mock_resources(type, schema, options, {"main.tf": `
 resource "aws_s3_bucket" "invalid" {
   bucket = "example-corp-assets"
 }`})
-test_deny_invalid_s3_bucket_name_failed if {
-  issues := deny_invalid_s3_bucket_name with terraform.resources as failed_resources
 
-  count(issues) == 1
-  issue := issues[_]
-  issue.msg == `Bucket names should always start with "example-com-"`
+test_deny_invalid_s3_bucket_name_failed if {
+	issues := deny_invalid_s3_bucket_name with terraform.resources as failed_resources
+
+	count(issues) == 1
+	issue := issues[_]
+	issue.msg == `Bucket names should always start with "example-com-"`
 }
 
 passed_resources(type, schema, options) := terraform.mock_resources(type, schema, options, {"main.tf": `
 resource "aws_s3_bucket" "valid" {
   bucket = "example-com-assets"
 }`})
-test_deny_invalid_s3_bucket_name_passed if {
-  issues := deny_invalid_s3_bucket_name with terraform.resources as passed_resources
 
-  count(issues) == 0
+test_deny_invalid_s3_bucket_name_passed if {
+	issues := deny_invalid_s3_bucket_name with terraform.resources as passed_resources
+
+	count(issues) == 0
 }
 
 unknown_resources(type, schema, options) := terraform.mock_resources(type, schema, options, {"main.tf": `
@@ -29,12 +32,13 @@ variable "unknown" {}
 resource "aws_s3_bucket" "invalid" {
   bucket = var.unknown
 }`})
-test_deny_invalid_s3_bucket_name_unknown if {
-  issues := deny_invalid_s3_bucket_name with terraform.resources as unknown_resources
 
-  count(issues) == 1
-  issue := issues[_]
-  issue.msg == "Dynamic value is not allowed in bucket"
+test_deny_invalid_s3_bucket_name_unknown if {
+	issues := deny_invalid_s3_bucket_name with terraform.resources as unknown_resources
+
+	count(issues) == 1
+	issue := issues[_]
+	issue.msg == "Dynamic value is not allowed in bucket"
 }
 
 unknown_count_resources(type, schema, options) := terraform.mock_resources(type, schema, options, {"main.tf": `
@@ -44,12 +48,13 @@ resource "aws_s3_bucket" "invalid" {
   count  = var.unknown
   bucket = "example-corp-assets"
 }`})
-test_deny_invalid_s3_bucket_name_unknown_count if {
-  issues := deny_invalid_s3_bucket_name with terraform.resources as failed_resources
 
-  count(issues) == 1
-  issue := issues[_]
-  issue.msg == `Bucket names should always start with "example-com-"`
+test_deny_invalid_s3_bucket_name_unknown_count if {
+	issues := deny_invalid_s3_bucket_name with terraform.resources as failed_resources
+
+	count(issues) == 1
+	issue := issues[_]
+	issue.msg == `Bucket names should always start with "example-com-"`
 }
 
 unknown_for_each_resources(type, schema, options) := terraform.mock_resources(type, schema, options, {"main.tf": `
@@ -59,10 +64,11 @@ resource "aws_s3_bucket" "invalid" {
   for_each = var.unknown
   bucket   = "example-corp-assets"
 }`})
-test_deny_invalid_s3_bucket_name_unknown_for_each if {
-  issues := deny_invalid_s3_bucket_name with terraform.resources as failed_resources
 
-  count(issues) == 1
-  issue := issues[_]
-  issue.msg == `Bucket names should always start with "example-com-"`
+test_deny_invalid_s3_bucket_name_unknown_for_each if {
+	issues := deny_invalid_s3_bucket_name with terraform.resources as failed_resources
+
+	count(issues) == 1
+	issue := issues[_]
+	issue.msg == `Bucket names should always start with "example-com-"`
 }

--- a/examples/enforce_bucket_names/README.md
+++ b/examples/enforce_bucket_names/README.md
@@ -20,27 +20,27 @@ Error: Bucket names should always start with "example-com-" (opa_deny_invalid_s3
   on main.tf line 2:
    2:   bucket = "example-corp-assets"
 
-Reference: .tflint.d/policies/bucket.rego:11
+Reference: .tflint.d/policies/bucket.rego:13
 
 Error: Dynamic value is not allowed in bucket (opa_deny_invalid_s3_bucket_name)
 
   on main.tf line 12:
   12:   bucket = var.unknown
 
-Reference: .tflint.d/policies/bucket.rego:11
+Reference: .tflint.d/policies/bucket.rego:13
 
 Error: Bucket names should always start with "example-com-" (opa_deny_invalid_s3_bucket_name)
 
   on main.tf line 18:
   18:   bucket = "example-corp-assets"
 
-Reference: .tflint.d/policies/bucket.rego:11
+Reference: .tflint.d/policies/bucket.rego:13
 
 Error: Bucket names should always start with "example-com-" (opa_deny_invalid_s3_bucket_name)
 
   on main.tf line 24:
   24:   bucket = "example-corp-assets"
 
-Reference: .tflint.d/policies/bucket.rego:11
+Reference: .tflint.d/policies/bucket.rego:13
 
 ```

--- a/examples/enforce_encrypted_devices/.tflint.d/policies/device.rego
+++ b/examples/enforce_encrypted_devices/.tflint.d/policies/device.rego
@@ -1,58 +1,65 @@
 package tflint
-import future.keywords.contains
-import future.keywords.if
+
+import rego.v1
 
 # Unexpanded resources: unknown check
 aws_instances_unexpanded := terraform.resources("aws_instance", {"count": "number", "for_each": "any", "dynamic": {"__labels": ["type"], "for_each": "any"}}, {"expand_mode": "none"})
 
 aws_instance_counts contains count if {
-  count := aws_instances_unexpanded[_].config.count
+	count := aws_instances_unexpanded[_].config.count
 }
+
 aws_instance_for_eachs contains for_each if {
-  for_each := aws_instances_unexpanded[_].config.for_each
+	for_each := aws_instances_unexpanded[_].config.for_each
 }
+
 dynamic_ebs_block_devices contains device if {
-  device := aws_instances_unexpanded[_].config.dynamic[_]
-  device.labels[0] == "ebs_block_device"
+	device := aws_instances_unexpanded[_].config.dynamic[_]
+	device.labels[0] == "ebs_block_device"
 }
 
 # Expanded resources: encrypted flag check
 aws_instances := terraform.resources("aws_instance", {"ebs_block_device": {"encrypted": "bool"}}, {})
 
 ebs_block_devices contains device if {
-  device := aws_instances[_].config.ebs_block_device[_]
+	device := aws_instances[_].config.ebs_block_device[_]
 }
 
 # Rules for unknown
-deny_unencrypted_ebs_block_device[issue] {
-  aws_instance_counts[i].unknown
+deny_unencrypted_ebs_block_device contains issue if {
+	aws_instance_counts[i].unknown
 
-  issue := tflint.issue("Dynamic value is not allowed in count", aws_instance_counts[i].range)
+	issue := tflint.issue("Dynamic value is not allowed in count", aws_instance_counts[i].range)
 }
-deny_unencrypted_ebs_block_device[issue] {
-  aws_instance_for_eachs[i].unknown
 
-  issue := tflint.issue("Dynamic value is not allowed in for_each", aws_instance_for_eachs[i].range)
-}
-deny_unencrypted_ebs_block_device[issue] {
-  dynamic_ebs_block_devices[i].config.for_each.unknown
+deny_unencrypted_ebs_block_device contains issue if {
+	aws_instance_for_eachs[i].unknown
 
-  issue := tflint.issue("Dynamic value is not allowed in for_each",  dynamic_ebs_block_devices[i].config.for_each.range)
+	issue := tflint.issue("Dynamic value is not allowed in for_each", aws_instance_for_eachs[i].range)
 }
-deny_unencrypted_ebs_block_device[issue] {
-  ebs_block_devices[i].config.encrypted.unknown
 
-  issue := tflint.issue("Dynamic value is not allowed in encrypted", ebs_block_devices[i].config.encrypted.range)
+deny_unencrypted_ebs_block_device contains issue if {
+	dynamic_ebs_block_devices[i].config.for_each.unknown
+
+	issue := tflint.issue("Dynamic value is not allowed in for_each", dynamic_ebs_block_devices[i].config.for_each.range)
 }
+
+deny_unencrypted_ebs_block_device contains issue if {
+	ebs_block_devices[i].config.encrypted.unknown
+
+	issue := tflint.issue("Dynamic value is not allowed in encrypted", ebs_block_devices[i].config.encrypted.range)
+}
+
 # Rules for undefined
-deny_unencrypted_ebs_block_device[issue] {
-  ebs_block_devices[i].config == {}
+deny_unencrypted_ebs_block_device contains issue if {
+	ebs_block_devices[i].config == {}
 
-  issue := tflint.issue("EBS block device must be encrypted", ebs_block_devices[i].decl_range)
+	issue := tflint.issue("EBS block device must be encrypted", ebs_block_devices[i].decl_range)
 }
-# Rules for invaid value and null
-deny_unencrypted_ebs_block_device[issue] {
-  ebs_block_devices[i].config.encrypted.value != true
 
-  issue := tflint.issue("EBS block device must be encrypted", ebs_block_devices[i].config.encrypted.range)
+# Rules for invaid value and null
+deny_unencrypted_ebs_block_device contains issue if {
+	ebs_block_devices[i].config.encrypted.value != true
+
+	issue := tflint.issue("EBS block device must be encrypted", ebs_block_devices[i].config.encrypted.range)
 }

--- a/examples/enforce_encrypted_devices/.tflint.d/policies/device_test.rego
+++ b/examples/enforce_encrypted_devices/.tflint.d/policies/device_test.rego
@@ -1,5 +1,6 @@
 package tflint
-import future.keywords.if
+
+import rego.v1
 
 failed_resources(type, schema, options) := terraform.mock_resources(type, schema, options, {"main.tf": `
 resource "aws_instance" "invalid" {
@@ -7,12 +8,13 @@ resource "aws_instance" "invalid" {
     encrypted = false
   }
 }`})
-test_deny_unencrypted_ebs_block_device_failed if {
-  issues := deny_unencrypted_ebs_block_device with terraform.resources as failed_resources
 
-  count(issues) == 1
-  issue := issues[_]
-  issue.msg == "EBS block device must be encrypted"
+test_deny_unencrypted_ebs_block_device_failed if {
+	issues := deny_unencrypted_ebs_block_device with terraform.resources as failed_resources
+
+	count(issues) == 1
+	issue := issues[_]
+	issue.msg == "EBS block device must be encrypted"
 }
 
 passed_resources(type, schema, options) := terraform.mock_resources(type, schema, options, {"main.tf": `
@@ -21,10 +23,11 @@ resource "aws_instance" "valid" {
     encrypted = true
   }
 }`})
-test_deny_unencrypted_ebs_block_device_passed if {
-  issues := deny_unencrypted_ebs_block_device with terraform.resources as passed_resources
 
-  count(issues) == 0
+test_deny_unencrypted_ebs_block_device_passed if {
+	issues := deny_unencrypted_ebs_block_device with terraform.resources as passed_resources
+
+	count(issues) == 0
 }
 
 default_resources(type, schema, options) := terraform.mock_resources(type, schema, options, {"main.tf": `
@@ -32,12 +35,13 @@ resource "aws_instance" "default" {
   ebs_block_device {
   }
 }`})
-test_deny_unencrypted_ebs_block_device_default if {
-  issues := deny_unencrypted_ebs_block_device with terraform.resources as default_resources
 
-  count(issues) == 1
-  issue := issues[_]
-  issue.msg == "EBS block device must be encrypted"
+test_deny_unencrypted_ebs_block_device_default if {
+	issues := deny_unencrypted_ebs_block_device with terraform.resources as default_resources
+
+	count(issues) == 1
+	issue := issues[_]
+	issue.msg == "EBS block device must be encrypted"
 }
 
 null_resources(type, schema, options) := terraform.mock_resources(type, schema, options, {"main.tf": `
@@ -46,12 +50,13 @@ resource "aws_instance" "null" {
     encrypted = null
   }
 }`})
-test_deny_unencrypted_ebs_block_device_default if {
-  issues := deny_unencrypted_ebs_block_device with terraform.resources as null_resources
 
-  count(issues) == 1
-  issue := issues[_]
-  issue.msg == "EBS block device must be encrypted"
+test_deny_unencrypted_ebs_block_device_default if {
+	issues := deny_unencrypted_ebs_block_device with terraform.resources as null_resources
+
+	count(issues) == 1
+	issue := issues[_]
+	issue.msg == "EBS block device must be encrypted"
 }
 
 unknown_resources(type, schema, options) := terraform.mock_resources(type, schema, options, {"main.tf": `
@@ -62,12 +67,13 @@ resource "aws_instance" "unknown" {
     encrypted = var.unknown
   }
 }`})
-test_deny_unencrypted_ebs_block_device_unknown if {
-  issues := deny_unencrypted_ebs_block_device with terraform.resources as unknown_resources
 
-  count(issues) == 1
-  issue := issues[_]
-  issue.msg == "Dynamic value is not allowed in encrypted"
+test_deny_unencrypted_ebs_block_device_unknown if {
+	issues := deny_unencrypted_ebs_block_device with terraform.resources as unknown_resources
+
+	count(issues) == 1
+	issue := issues[_]
+	issue.msg == "Dynamic value is not allowed in encrypted"
 }
 
 unknown_count_resources(type, schema, options) := terraform.mock_resources(type, schema, options, {"main.tf": `
@@ -76,12 +82,13 @@ variable "unknown" {}
 resource "aws_instance" "unknown_count" {
   count = var.unknown
 }`})
-test_deny_unencrypted_ebs_block_device_unknown_count if {
-  issues := deny_unencrypted_ebs_block_device with terraform.resources as unknown_count_resources
 
-  count(issues) == 1
-  issue := issues[_]
-  issue.msg == "Dynamic value is not allowed in count"
+test_deny_unencrypted_ebs_block_device_unknown_count if {
+	issues := deny_unencrypted_ebs_block_device with terraform.resources as unknown_count_resources
+
+	count(issues) == 1
+	issue := issues[_]
+	issue.msg == "Dynamic value is not allowed in count"
 }
 
 unknown_for_each_resources(type, schema, options) := terraform.mock_resources(type, schema, options, {"main.tf": `
@@ -90,12 +97,13 @@ variable "unknown" {}
 resource "aws_instance" "unknown_for_each" {
   for_each = var.unknown
 }`})
-test_deny_unencrypted_ebs_block_device_unknown_for_each if {
-  issues := deny_unencrypted_ebs_block_device with terraform.resources as unknown_for_each_resources
 
-  count(issues) == 1
-  issue := issues[_]
-  issue.msg == "Dynamic value is not allowed in for_each"
+test_deny_unencrypted_ebs_block_device_unknown_for_each if {
+	issues := deny_unencrypted_ebs_block_device with terraform.resources as unknown_for_each_resources
+
+	count(issues) == 1
+	issue := issues[_]
+	issue.msg == "Dynamic value is not allowed in for_each"
 }
 
 unknown_dynamic_resources(type, schema, options) := terraform.mock_resources(type, schema, options, {"main.tf": `
@@ -106,10 +114,11 @@ resource "aws_instance" "unknown_dynamic" {
     for_each = var.unknown
   }
 }`})
-test_deny_unencrypted_ebs_block_device_unknown_dynamic if {
-  issues := deny_unencrypted_ebs_block_device with terraform.resources as unknown_dynamic_resources
 
-  count(issues) == 1
-  issue := issues[_]
-  issue.msg == "Dynamic value is not allowed in for_each"
+test_deny_unencrypted_ebs_block_device_unknown_dynamic if {
+	issues := deny_unencrypted_ebs_block_device with terraform.resources as unknown_dynamic_resources
+
+	count(issues) == 1
+	issue := issues[_]
+	issue.msg == "Dynamic value is not allowed in for_each"
 }

--- a/examples/enforce_encrypted_devices/README.md
+++ b/examples/enforce_encrypted_devices/README.md
@@ -13,62 +13,62 @@ This is an example of rules for attributes in nested blocks.
 
 ```console
 $ tflint
-7 issue(s) found:
+8 issue(s) found:
 
 Error: EBS block device must be encrypted (opa_deny_unencrypted_ebs_block_device)
 
   on main.tf line 3:
    3:     encrypted = false
 
-Reference: .tflint.d/policies/device.rego:27
+Reference: .tflint.d/policies/device.rego:29
 
 Error: EBS block device must be encrypted (opa_deny_unencrypted_ebs_block_device)
 
   on main.tf line 14:
   14:   ebs_block_device {
 
-Reference: .tflint.d/policies/device.rego:27
+Reference: .tflint.d/policies/device.rego:29
 
 Error: EBS block device must be encrypted (opa_deny_unencrypted_ebs_block_device)
 
   on main.tf line 20:
   20:     encrypted = null
 
-Reference: .tflint.d/policies/device.rego:27
+Reference: .tflint.d/policies/device.rego:29
 
 Error: EBS block device must be encrypted (opa_deny_unencrypted_ebs_block_device)
 
   on main.tf line 29:
   29:       encrypted = ebs_block_device.value
 
-Reference: .tflint.d/policies/device.rego:27
+Reference: .tflint.d/policies/device.rego:29
 
 Error: Dynamic value is not allowed in encrypted (opa_deny_unencrypted_ebs_block_device)
 
   on main.tf line 38:
   38:     encrypted = var.unknown
 
-Reference: .tflint.d/policies/device.rego:27
+Reference: .tflint.d/policies/device.rego:29
 
 Error: Dynamic value is not allowed in count (opa_deny_unencrypted_ebs_block_device)
 
   on main.tf line 43:
   43:   count = var.unknown
 
-Reference: .tflint.d/policies/device.rego:27
+Reference: .tflint.d/policies/device.rego:29
 
 Error: Dynamic value is not allowed in for_each (opa_deny_unencrypted_ebs_block_device)
 
   on main.tf line 51:
   51:   for_each = var.unknown
 
-Reference: .tflint.d/policies/device.rego:27
+Reference: .tflint.d/policies/device.rego:29
 
 Error: Dynamic value is not allowed in for_each (opa_deny_unencrypted_ebs_block_device)
 
   on main.tf line 60:
   60:     for_each = var.unknown
 
-Reference: .tflint.d/policies/device.rego:27
+Reference: .tflint.d/policies/device.rego:29
 
 ```

--- a/examples/enforce_modules/.tflint.d/policies/module.rego
+++ b/examples/enforce_modules/.tflint.d/policies/module.rego
@@ -1,8 +1,10 @@
 package tflint
 
-deny_resource_declarations[issue] {
-  resources := terraform.resources("*", {}, {"expand_mode": "none"})
-  count(resources) > 0
+import rego.v1
 
-  issue := tflint.issue("Declaring resources is not allowed. Use modules instead.", resources[0].decl_range)
+deny_resource_declarations contains issue if {
+	resources := terraform.resources("*", {}, {"expand_mode": "none"})
+	count(resources) > 0
+
+	issue := tflint.issue("Declaring resources is not allowed. Use modules instead.", resources[0].decl_range)
 }

--- a/examples/enforce_modules/.tflint.d/policies/module_test.rego
+++ b/examples/enforce_modules/.tflint.d/policies/module_test.rego
@@ -1,16 +1,18 @@
 package tflint
-import future.keywords.if
+
+import rego.v1
 
 failed_resources(type, schema, options) := terraform.mock_resources(type, schema, options, {"main.tf": `
 resource "aws_instance" "main" {
   instance_type = "t2.micro"
 }`})
-test_deny_resource_declarations_failed if {
-  issues := deny_resource_declarations with terraform.resources as failed_resources
 
-  count(issues) == 1
-  issue := issues[_]
-  issue.msg == "Declaring resources is not allowed. Use modules instead."
+test_deny_resource_declarations_failed if {
+	issues := deny_resource_declarations with terraform.resources as failed_resources
+
+	count(issues) == 1
+	issue := issues[_]
+	issue.msg == "Declaring resources is not allowed. Use modules instead."
 }
 
 passed_resources(type, schema, options) := terraform.mock_resources(type, schema, options, {"main.tf": `
@@ -19,8 +21,9 @@ module "aws_instance" {
 
   instance_type = "t2.micro"
 }`})
-test_deny_resource_declarations_passed if {
-  issues := deny_resource_declarations with terraform.resources as passed_resources
 
-  count(issues) == 0
+test_deny_resource_declarations_passed if {
+	issues := deny_resource_declarations with terraform.resources as passed_resources
+
+	count(issues) == 0
 }

--- a/examples/enforce_modules/README.md
+++ b/examples/enforce_modules/README.md
@@ -17,6 +17,6 @@ Error: Declaring resources is not allowed. Use modules instead. (opa_deny_resour
   on main.tf line 1:
    1: resource "aws_instance" "main" {
 
-Reference: .tflint.d/policies/module.rego:3
+Reference: .tflint.d/policies/module.rego:5
 
 ```

--- a/examples/enforce_tags/.tflint.d/policies/tags.rego
+++ b/examples/enforce_tags/.tflint.d/policies/tags.rego
@@ -1,33 +1,35 @@
 package tflint
 
+import rego.v1
+
 aws_instances := terraform.resources("aws_instance", {"tags": "map(string)"}, {"expand_mode": "none"})
 
-contains(array, elem) {
-  array[_] = elem
-}
 # "tags" is null
-is_untagged(config) {
-  is_null(config.tags.value)
+is_untagged(config) if {
+	is_null(config.tags.value)
 }
+
 # "tags" is defined, but "Environment" not found
-is_untagged(config) {
-  not is_null(config.tags.value)
-  not contains(object.keys(config.tags.value), "Environment")
+is_untagged(config) if {
+	not is_null(config.tags.value)
+	not "Environment" in object.keys(config.tags.value)
 }
+
 # "tags" is not defined
-is_untagged(config) {
-  not contains(object.keys(config), "tags")
+is_untagged(config) if {
+	not "tags" in object.keys(config)
 }
 
 # Rules for unknown tags
-deny_untagged_instance[issue] {
-  aws_instances[i].config.tags.unknown
+deny_untagged_instance contains issue if {
+	aws_instances[i].config.tags.unknown
 
-  issue := tflint.issue("Dynamic value is not allowed in tags", aws_instances[i].config.tags.range)
+	issue := tflint.issue("Dynamic value is not allowed in tags", aws_instances[i].config.tags.range)
 }
-# Rules for invalid tags
-deny_untagged_instance[issue] {
-  is_untagged(aws_instances[i].config)
 
-  issue := tflint.issue(`instance must be tagged with the "Environment" tag`, aws_instances[i].decl_range)
+# Rules for invalid tags
+deny_untagged_instance contains issue if {
+	is_untagged(aws_instances[i].config)
+
+	issue := tflint.issue(`instance must be tagged with the "Environment" tag`, aws_instances[i].decl_range)
 }

--- a/examples/enforce_tags/.tflint.d/policies/tags_test.rego
+++ b/examples/enforce_tags/.tflint.d/policies/tags_test.rego
@@ -1,5 +1,6 @@
 package tflint
-import future.keywords.if
+
+import rego.v1
 
 failed_resources(type, schema, options) := terraform.mock_resources(type, schema, options, {"main.tf": `
 resource "aws_instance" "invalid" {
@@ -7,14 +8,14 @@ resource "aws_instance" "invalid" {
     "production" = true
   }
 }`})
+
 test_deny_untagged_instance_failed if {
-  issues := deny_untagged_instance with terraform.resources as failed_resources
+	issues := deny_untagged_instance with terraform.resources as failed_resources
 
-  count(issues) == 1
-  issue := issues[_]
-  issue.msg == `instance must be tagged with the "Environment" tag`
+	count(issues) == 1
+	issue := issues[_]
+	issue.msg == `instance must be tagged with the "Environment" tag`
 }
-
 
 passed_resources(type, schema, options) := terraform.mock_resources(type, schema, options, {"main.tf": `
 resource "aws_instance" "valid" {
@@ -22,33 +23,36 @@ resource "aws_instance" "valid" {
     "Environment" = "production"
   }
 }`})
-test_deny_untagged_instance_passed if {
-  issues := deny_untagged_instance with terraform.resources as passed_resources
 
-  count(issues) == 0
+test_deny_untagged_instance_passed if {
+	issues := deny_untagged_instance with terraform.resources as passed_resources
+
+	count(issues) == 0
 }
 
 undef_resources(type, schema, options) := terraform.mock_resources(type, schema, options, {"main.tf": `
 resource "aws_instance" "undef" {
 }`})
-test_deny_untagged_instance_undef if {
-  issues := deny_untagged_instance with terraform.resources as undef_resources
 
-  count(issues) == 1
-  issue := issues[_]
-  issue.msg == `instance must be tagged with the "Environment" tag`
+test_deny_untagged_instance_undef if {
+	issues := deny_untagged_instance with terraform.resources as undef_resources
+
+	count(issues) == 1
+	issue := issues[_]
+	issue.msg == `instance must be tagged with the "Environment" tag`
 }
 
 null_resources(type, schema, options) := terraform.mock_resources(type, schema, options, {"main.tf": `
 resource "aws_instance" "undef" {
   tags = null
 }`})
-test_deny_untagged_instance_null if {
-  issues := deny_untagged_instance with terraform.resources as null_resources
 
-  count(issues) == 1
-  issue := issues[_]
-  issue.msg == `instance must be tagged with the "Environment" tag`
+test_deny_untagged_instance_null if {
+	issues := deny_untagged_instance with terraform.resources as null_resources
+
+	count(issues) == 1
+	issue := issues[_]
+	issue.msg == `instance must be tagged with the "Environment" tag`
 }
 
 unknown_resources(type, schema, options) := terraform.mock_resources(type, schema, options, {"main.tf": `
@@ -57,10 +61,11 @@ variable "unknown" {}
 resource "aws_instance" "unknown" {
   tags = var.unknown
 }`})
-test_deny_untagged_instance_null if {
-  issues := deny_untagged_instance with terraform.resources as unknown_resources
 
-  count(issues) == 1
-  issue := issues[_]
-  issue.msg == "Dynamic value is not allowed in tags"
+test_deny_untagged_instance_null if {
+	issues := deny_untagged_instance with terraform.resources as unknown_resources
+
+	count(issues) == 1
+	issue := issues[_]
+	issue.msg == "Dynamic value is not allowed in tags"
 }

--- a/examples/enforce_tags/README.md
+++ b/examples/enforce_tags/README.md
@@ -19,27 +19,27 @@ Error: instance must be tagged with the "Environment" tag (opa_deny_untagged_ins
   on main.tf line 1:
    1: resource "aws_instance" "invalid" {
 
-Reference: .tflint.d/policies/tags.rego:23
+Reference: .tflint.d/policies/tags.rego:24
 
 Error: instance must be tagged with the "Environment" tag (opa_deny_untagged_instance)
 
   on main.tf line 13:
   13: resource "aws_instance" "undefined" {
 
-Reference: .tflint.d/policies/tags.rego:23
+Reference: .tflint.d/policies/tags.rego:24
 
 Error: instance must be tagged with the "Environment" tag (opa_deny_untagged_instance)
 
   on main.tf line 16:
   16: resource "aws_instance" "null" {
 
-Reference: .tflint.d/policies/tags.rego:23
+Reference: .tflint.d/policies/tags.rego:24
 
 Error: Dynamic value is not allowed in tags (opa_deny_untagged_instance)
 
   on main.tf line 23:
   23:   tags = var.unknown
 
-Reference: .tflint.d/policies/tags.rego:23
+Reference: .tflint.d/policies/tags.rego:24
 
 ```

--- a/integration/checks/policies/main.rego
+++ b/integration/checks/policies/main.rego
@@ -1,9 +1,11 @@
 package tflint
 
-deny_deterministic_check_condition[issue] {
-  checks := terraform.checks({"assert": {"condition": "bool"}}, {})
-  condition = checks[_].config.assert[_].config.condition
-  condition.unknown == false
+import rego.v1
 
-  issue := tflint.issue("deterministic check condtion is not allowed", condition.range)
+deny_deterministic_check_condition contains issue if {
+	checks := terraform.checks({"assert": {"condition": "bool"}}, {})
+	condition = checks[_].config.assert[_].config.condition
+	condition.unknown == false
+
+	issue := tflint.issue("deterministic check condtion is not allowed", condition.range)
 }

--- a/integration/checks/policies/main_test.rego
+++ b/integration/checks/policies/main_test.rego
@@ -1,5 +1,6 @@
 package tflint
-import future.keywords
+
+import rego.v1
 
 mock_checks(schema, options) := terraform.mock_checks(schema, options, {"main.tf": `
 check "deterministic" {
@@ -10,15 +11,15 @@ check "deterministic" {
 }`})
 
 test_deny_deterministic_check_condition_passed if {
-  issues := deny_deterministic_check_condition with terraform.checks as mock_checks
+	issues := deny_deterministic_check_condition with terraform.checks as mock_checks
 
-  count(issues) == 1
-  issue := issues[_]
-  issue.msg == "deterministic check condtion is not allowed"
+	count(issues) == 1
+	issue := issues[_]
+	issue.msg == "deterministic check condtion is not allowed"
 }
 
 test_deny_deterministic_check_condition_failed if {
-  issues := deny_deterministic_check_condition with terraform.checks as mock_checks
+	issues := deny_deterministic_check_condition with terraform.checks as mock_checks
 
-  count(issues) == 0
+	count(issues) == 0
 }

--- a/integration/checks/result.json
+++ b/integration/checks/result.json
@@ -4,7 +4,7 @@
       "rule": {
         "name": "opa_deny_deterministic_check_condition",
         "severity": "error",
-        "link": "policies/main.rego:3"
+        "link": "policies/main.rego:5"
       },
       "message": "deterministic check condtion is not allowed",
       "range": {

--- a/integration/checks/result_test.json
+++ b/integration/checks/result_test.json
@@ -4,7 +4,7 @@
       "rule": {
         "name": "opa_test_deny_deterministic_check_condition_failed",
         "severity": "error",
-        "link": "policies/main_test.rego:20"
+        "link": "policies/main_test.rego:21"
       },
       "message": "test failed",
       "range": {

--- a/integration/data_sources/policies/main.rego
+++ b/integration/data_sources/policies/main.rego
@@ -1,10 +1,12 @@
 package tflint
 
-deny_other_ami_owners[issue] {
-  sources := terraform.data_sources("aws_ami", {"owners": "list(string)"}, {})
-  owners := sources[_].config.owners
+import rego.v1
 
-  owners.value[_] != "self"
+deny_other_ami_owners contains issue if {
+	sources := terraform.data_sources("aws_ami", {"owners": "list(string)"}, {})
+	owners := sources[_].config.owners
 
-  issue := tflint.issue("third-party AMI is not allowed", owners.range)
+	owners.value[_] != "self"
+
+	issue := tflint.issue("third-party AMI is not allowed", owners.range)
 }

--- a/integration/data_sources/policies/main_test.rego
+++ b/integration/data_sources/policies/main_test.rego
@@ -1,5 +1,6 @@
 package tflint
-import future.keywords
+
+import rego.v1
 
 mock_data_sources(type, schema, options) := terraform.mock_data_sources(type, schema, options, {"main.tf": `
 data "aws_ami" "main" {
@@ -13,15 +14,15 @@ check "scope" {
 }`})
 
 test_deny_other_ami_owners_passed if {
-  issues := deny_other_ami_owners with terraform.data_sources as mock_data_sources
+	issues := deny_other_ami_owners with terraform.data_sources as mock_data_sources
 
-  count(issues) == 2
-  issue := issues[_]
-  issue.msg == "third-party AMI is not allowed"
+	count(issues) == 2
+	issue := issues[_]
+	issue.msg == "third-party AMI is not allowed"
 }
 
 test_deny_other_ami_owners_failed if {
-  issues := deny_other_ami_owners with terraform.data_sources as mock_data_sources
+	issues := deny_other_ami_owners with terraform.data_sources as mock_data_sources
 
-  count(issues) == 0
+	count(issues) == 0
 }

--- a/integration/data_sources/result.json
+++ b/integration/data_sources/result.json
@@ -4,7 +4,7 @@
       "rule": {
         "name": "opa_deny_other_ami_owners",
         "severity": "error",
-        "link": "policies/main.rego:3"
+        "link": "policies/main.rego:5"
       },
       "message": "third-party AMI is not allowed",
       "range": {
@@ -24,7 +24,7 @@
       "rule": {
         "name": "opa_deny_other_ami_owners",
         "severity": "error",
-        "link": "policies/main.rego:3"
+        "link": "policies/main.rego:5"
       },
       "message": "third-party AMI is not allowed",
       "range": {

--- a/integration/data_sources/result_test.json
+++ b/integration/data_sources/result_test.json
@@ -4,7 +4,7 @@
       "rule": {
         "name": "opa_test_deny_other_ami_owners_failed",
         "severity": "error",
-        "link": "policies/main_test.rego:23"
+        "link": "policies/main_test.rego:24"
       },
       "message": "test failed",
       "range": {

--- a/integration/imports/policies/main.rego
+++ b/integration/imports/policies/main.rego
@@ -1,8 +1,10 @@
 package tflint
 
-deny_import_blocks[issue] {
-  imports := terraform.imports({}, {})
-  count(imports) > 0
+import rego.v1
 
-  issue := tflint.issue("import blocks are not allowed", imports[0].decl_range)
+deny_import_blocks contains issue if {
+	imports := terraform.imports({}, {})
+	count(imports) > 0
+
+	issue := tflint.issue("import blocks are not allowed", imports[0].decl_range)
 }

--- a/integration/imports/policies/main_test.rego
+++ b/integration/imports/policies/main_test.rego
@@ -1,5 +1,6 @@
 package tflint
-import future.keywords
+
+import rego.v1
 
 mock_imports(schema, options) := terraform.mock_imports(schema, options, {"main.tf": `
 import {
@@ -8,15 +9,15 @@ import {
 }`})
 
 test_deny_import_blocks_passed if {
-  issues := deny_import_blocks with terraform.imports as mock_imports
+	issues := deny_import_blocks with terraform.imports as mock_imports
 
-  count(issues) == 1
-  issue := issues[_]
-  issue.msg == "import blocks are not allowed"
+	count(issues) == 1
+	issue := issues[_]
+	issue.msg == "import blocks are not allowed"
 }
 
 test_deny_import_blocks_failed if {
-  issues := deny_import_blocks with terraform.imports as mock_imports
+	issues := deny_import_blocks with terraform.imports as mock_imports
 
-  count(issues) == 0
+	count(issues) == 0
 }

--- a/integration/imports/result.json
+++ b/integration/imports/result.json
@@ -4,7 +4,7 @@
       "rule": {
         "name": "opa_deny_import_blocks",
         "severity": "error",
-        "link": "policies/main.rego:3"
+        "link": "policies/main.rego:5"
       },
       "message": "import blocks are not allowed",
       "range": {

--- a/integration/imports/result_test.json
+++ b/integration/imports/result_test.json
@@ -4,7 +4,7 @@
       "rule": {
         "name": "opa_test_deny_import_blocks_failed",
         "severity": "error",
-        "link": "policies/main_test.rego:18"
+        "link": "policies/main_test.rego:19"
       },
       "message": "test failed",
       "range": {

--- a/integration/instance_type/policies/main.rego
+++ b/integration/instance_type/policies/main.rego
@@ -1,28 +1,30 @@
 package tflint
 
-deny_not_t2_micro[issue] {
-  resources := terraform.resources("aws_instance", {"instance_type": "string"}, {})
-  instance_type := resources[_].config.instance_type
+import rego.v1
 
-  instance_type.unknown == true
+deny_not_t2_micro contains issue if {
+	resources := terraform.resources("aws_instance", {"instance_type": "string"}, {})
+	instance_type := resources[_].config.instance_type
 
-  issue := tflint.issue("instance type is unknown", instance_type.range)
+	instance_type.unknown == true
+
+	issue := tflint.issue("instance type is unknown", instance_type.range)
 }
 
-deny_not_t2_micro[issue] {
-  resources := terraform.resources("aws_instance", {"instance_type": "string"}, {})
-  instance_type := resources[_].config.instance_type
+deny_not_t2_micro contains issue if {
+	resources := terraform.resources("aws_instance", {"instance_type": "string"}, {})
+	instance_type := resources[_].config.instance_type
 
-  instance_type.sensitive == true
+	instance_type.sensitive == true
 
-  issue := tflint.issue("instance type is sensitive", instance_type.range)
+	issue := tflint.issue("instance type is sensitive", instance_type.range)
 }
 
-deny_not_t2_micro[issue] {
-  resources := terraform.resources("aws_instance", {"instance_type": "string"}, {})
-  instance_type := resources[_].config.instance_type
+deny_not_t2_micro contains issue if {
+	resources := terraform.resources("aws_instance", {"instance_type": "string"}, {})
+	instance_type := resources[_].config.instance_type
 
-  instance_type.value != "t2.micro"
+	instance_type.value != "t2.micro"
 
-  issue := tflint.issue("t2.micro is only allowed", instance_type.range)
+	issue := tflint.issue("t2.micro is only allowed", instance_type.range)
 }

--- a/integration/instance_type/result_test.json
+++ b/integration/instance_type/result_test.json
@@ -4,7 +4,7 @@
       "rule": {
         "name": "opa_test_not_deny_t2_micro_failed",
         "severity": "error",
-        "link": "policies/main_test.rego:17"
+        "link": "policies/main_test.rego:18"
       },
       "message": "test failed",
       "range": {
@@ -24,7 +24,7 @@
       "rule": {
         "name": "opa_test_not_deny_t2_micro_unknown_failed",
         "severity": "error",
-        "link": "policies/main_test.rego:37"
+        "link": "policies/main_test.rego:38"
       },
       "message": "test failed",
       "range": {
@@ -44,7 +44,7 @@
       "rule": {
         "name": "opa_test_not_deny_t2_micro_sensitive_failed",
         "severity": "error",
-        "link": "policies/main_test.rego:58"
+        "link": "policies/main_test.rego:59"
       },
       "message": "test failed",
       "range": {

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -236,6 +236,17 @@ func TestIntegration(t *testing.T) {
 			dir:     "removed",
 			test:    true,
 		},
+		{
+			name:    "legacy Rego syntax",
+			command: exec.Command("tflint", "--format", "json", "--force"),
+			dir:     "legacy_rego_syntax",
+		},
+		{
+			name:    "legacy Rego syntax (test)",
+			command: exec.Command("tflint", "--format", "json", "--force"),
+			dir:     "legacy_rego_syntax",
+			test:    true,
+		},
 	}
 
 	dir, _ := os.Getwd()

--- a/integration/legacy_rego_syntax/.tflint.hcl
+++ b/integration/legacy_rego_syntax/.tflint.hcl
@@ -1,0 +1,9 @@
+plugin "terraform" {
+  enabled = false
+}
+
+plugin "opa" {
+  enabled = true
+
+  policy_dir = "policies"
+}

--- a/integration/legacy_rego_syntax/main.tf
+++ b/integration/legacy_rego_syntax/main.tf
@@ -1,0 +1,27 @@
+resource "aws_instance" "invalid" {
+  instance_type = "t1.micro"
+}
+
+resource "aws_instance" "valid" {
+  instance_type = "t2.micro"
+}
+
+variable "variable" {
+  default = "m5.large"
+}
+resource "aws_instance" "variable" {
+  instance_type = var.variable
+}
+
+variable "unknown" {}
+resource "aws_instance" "variable" {
+  instance_type = var.unknown
+}
+
+variable "sensitive" {
+  default   = "m5.large"
+  sensitive = true
+}
+resource "aws_instance" "sensitive" {
+  instance_type = var.sensitive
+}

--- a/integration/legacy_rego_syntax/policies/main.rego
+++ b/integration/legacy_rego_syntax/policies/main.rego
@@ -1,0 +1,28 @@
+package tflint
+
+deny_not_t2_micro[issue] {
+  resources := terraform.resources("aws_instance", {"instance_type": "string"}, {})
+  instance_type := resources[_].config.instance_type
+
+  instance_type.unknown == true
+
+  issue := tflint.issue("instance type is unknown", instance_type.range)
+}
+
+deny_not_t2_micro[issue] {
+  resources := terraform.resources("aws_instance", {"instance_type": "string"}, {})
+  instance_type := resources[_].config.instance_type
+
+  instance_type.sensitive == true
+
+  issue := tflint.issue("instance type is sensitive", instance_type.range)
+}
+
+deny_not_t2_micro[issue] {
+  resources := terraform.resources("aws_instance", {"instance_type": "string"}, {})
+  instance_type := resources[_].config.instance_type
+
+  instance_type.value != "t2.micro"
+
+  issue := tflint.issue("t2.micro is only allowed", instance_type.range)
+}

--- a/integration/legacy_rego_syntax/policies/main_test.rego
+++ b/integration/legacy_rego_syntax/policies/main_test.rego
@@ -1,6 +1,5 @@
 package tflint
-
-import rego.v1
+import future.keywords
 
 mock_resources_t1_micro(type, schema, options) := terraform.mock_resources(type, schema, options, {"main.tf": `
 resource "aws_instance" "main" {
@@ -8,17 +7,17 @@ resource "aws_instance" "main" {
 }`})
 
 test_not_deny_t2_micro_passed if {
-	issues := deny_not_t2_micro with terraform.resources as mock_resources_t1_micro
+  issues := deny_not_t2_micro with terraform.resources as mock_resources_t1_micro
 
-	count(issues) == 1
-	issue := issues[_]
-	issue.msg == "t2.micro is only allowed"
+  count(issues) == 1
+  issue := issues[_]
+  issue.msg == "t2.micro is only allowed"
 }
 
 test_not_deny_t2_micro_failed if {
-	issues := deny_not_t2_micro with terraform.resources as mock_resources_t1_micro
+  issues := deny_not_t2_micro with terraform.resources as mock_resources_t1_micro
 
-	count(issues) == 0
+  count(issues) == 0
 }
 
 mock_resources_unknown_instance_type(type, schema, options) := terraform.mock_resources(type, schema, options, {"main.tf": `
@@ -28,17 +27,17 @@ resource "aws_instance" "main" {
 }`})
 
 test_not_deny_t2_micro_unknown_passed if {
-	issues := deny_not_t2_micro with terraform.resources as mock_resources_unknown_instance_type
+  issues := deny_not_t2_micro with terraform.resources as mock_resources_unknown_instance_type
 
-	count(issues) == 1
-	issue := issues[_]
-	issue.msg == "instance type is unknown"
+  count(issues) == 1
+  issue := issues[_]
+  issue.msg == "instance type is unknown"
 }
 
 test_not_deny_t2_micro_unknown_failed if {
-	issues := deny_not_t2_micro with terraform.resources as mock_resources_unknown_instance_type
+  issues := deny_not_t2_micro with terraform.resources as mock_resources_unknown_instance_type
 
-	count(issues) == 0
+  count(issues) == 0
 }
 
 mock_resources_sensitive_instance_type(type, schema, options) := terraform.mock_resources(type, schema, options, {"main.tf": `
@@ -51,13 +50,13 @@ resource "aws_instance" "main" {
 }`})
 
 test_not_deny_t2_micro_sensitive_passed if {
-	issues := deny_not_t2_micro with terraform.resources as mock_resources_sensitive_instance_type
+  issues := deny_not_t2_micro with terraform.resources as mock_resources_sensitive_instance_type
 
-	count(issues) == 2
+  count(issues) == 2
 }
 
 test_not_deny_t2_micro_sensitive_failed if {
-	issues := deny_not_t2_micro with terraform.resources as mock_resources_sensitive_instance_type
+  issues := deny_not_t2_micro with terraform.resources as mock_resources_sensitive_instance_type
 
-	count(issues) == 0
+  count(issues) == 0
 }

--- a/integration/legacy_rego_syntax/result.json
+++ b/integration/legacy_rego_syntax/result.json
@@ -4,7 +4,7 @@
       "rule": {
         "name": "opa_deny_not_t2_micro",
         "severity": "error",
-        "link": "policies/main.rego:5"
+        "link": "policies/main.rego:3"
       },
       "message": "t2.micro is only allowed",
       "range": {
@@ -24,7 +24,7 @@
       "rule": {
         "name": "opa_deny_not_t2_micro",
         "severity": "error",
-        "link": "policies/main.rego:5"
+        "link": "policies/main.rego:3"
       },
       "message": "t2.micro is only allowed",
       "range": {
@@ -44,7 +44,7 @@
       "rule": {
         "name": "opa_deny_not_t2_micro",
         "severity": "error",
-        "link": "policies/main.rego:5"
+        "link": "policies/main.rego:3"
       },
       "message": "instance type is unknown",
       "range": {
@@ -64,7 +64,7 @@
       "rule": {
         "name": "opa_deny_not_t2_micro",
         "severity": "error",
-        "link": "policies/main.rego:5"
+        "link": "policies/main.rego:3"
       },
       "message": "instance type is sensitive",
       "range": {
@@ -84,7 +84,7 @@
       "rule": {
         "name": "opa_deny_not_t2_micro",
         "severity": "error",
-        "link": "policies/main.rego:5"
+        "link": "policies/main.rego:3"
       },
       "message": "instance type is unknown",
       "range": {

--- a/integration/legacy_rego_syntax/result_test.json
+++ b/integration/legacy_rego_syntax/result_test.json
@@ -2,7 +2,7 @@
   "issues": [
     {
       "rule": {
-        "name": "opa_test_deny_all_resources_failed",
+        "name": "opa_test_not_deny_t2_micro_failed",
         "severity": "error",
         "link": "policies/main_test.rego:17"
       },
@@ -22,9 +22,29 @@
     },
     {
       "rule": {
-        "name": "opa_test_deny_no_resources_failed",
+        "name": "opa_test_not_deny_t2_micro_unknown_failed",
         "severity": "error",
-        "link": "policies/main_test.rego:33"
+        "link": "policies/main_test.rego:37"
+      },
+      "message": "test failed",
+      "range": {
+        "filename": "",
+        "start": {
+          "line": 0,
+          "column": 0
+        },
+        "end": {
+          "line": 0,
+          "column": 0
+        }
+      },
+      "callers": []
+    },
+    {
+      "rule": {
+        "name": "opa_test_not_deny_t2_micro_sensitive_failed",
+        "severity": "error",
+        "link": "policies/main_test.rego:58"
       },
       "message": "test failed",
       "range": {

--- a/integration/locals/policies/main.rego
+++ b/integration/locals/policies/main.rego
@@ -1,8 +1,10 @@
 package tflint
 
-deny_too_many_locals[issue] {
-  locals := terraform.locals({})
-  count(locals) > 5
+import rego.v1
 
-  issue := tflint.issue("too many local values", terraform.module_range())
+deny_too_many_locals contains issue if {
+	locals := terraform.locals({})
+	count(locals) > 5
+
+	issue := tflint.issue("too many local values", terraform.module_range())
 }

--- a/integration/locals/policies/main_test.rego
+++ b/integration/locals/policies/main_test.rego
@@ -1,18 +1,19 @@
 package tflint
-import future.keywords
+
+import rego.v1
 
 mock_locals(options) := terraform.mock_locals(options, {})
 
 test_deny_too_many_locals_passed if {
-  issues := deny_too_many_locals with terraform.locals as mock_locals
+	issues := deny_too_many_locals with terraform.locals as mock_locals
 
-  count(issues) == 1
-  issue := issues[_]
-  issue.msg == "module must expose outputs"
+	count(issues) == 1
+	issue := issues[_]
+	issue.msg == "module must expose outputs"
 }
 
 test_deny_too_many_locals_failed if {
-  issues := deny_too_many_locals with terraform.locals as mock_locals
+	issues := deny_too_many_locals with terraform.locals as mock_locals
 
-  count(issues) == 0
+	count(issues) == 0
 }

--- a/integration/locals/result.json
+++ b/integration/locals/result.json
@@ -4,7 +4,7 @@
       "rule": {
         "name": "opa_deny_too_many_locals",
         "severity": "error",
-        "link": "policies/main.rego:3"
+        "link": "policies/main.rego:5"
       },
       "message": "too many local values",
       "range": {

--- a/integration/locals/result_test.json
+++ b/integration/locals/result_test.json
@@ -4,7 +4,7 @@
       "rule": {
         "name": "opa_test_deny_too_many_locals_passed",
         "severity": "error",
-        "link": "policies/main_test.rego:6"
+        "link": "policies/main_test.rego:7"
       },
       "message": "test failed",
       "range": {

--- a/integration/module_calls/policies/main.rego
+++ b/integration/module_calls/policies/main.rego
@@ -1,10 +1,12 @@
 package tflint
 
-deny_remote_source[issue] {
-  modules := terraform.module_calls({"source": "string"}, {})
-  source := modules[_].config.source
+import rego.v1
 
-  not startswith(source.value, "./")
+deny_remote_source contains issue if {
+	modules := terraform.module_calls({"source": "string"}, {})
+	source := modules[_].config.source
 
-  issue := tflint.issue("remote module is not allowed", source.range)
+	not startswith(source.value, "./")
+
+	issue := tflint.issue("remote module is not allowed", source.range)
 }

--- a/integration/module_calls/policies/main_test.rego
+++ b/integration/module_calls/policies/main_test.rego
@@ -1,5 +1,6 @@
 package tflint
-import future.keywords
+
+import rego.v1
 
 mock_module_calls(schema, options) := terraform.mock_module_calls(schema, options, {"main.tf": `
 module "remote" {
@@ -7,15 +8,15 @@ module "remote" {
 }`})
 
 test_deny_remote_source_passed if {
-  issues := deny_remote_source with terraform.module_calls as mock_module_calls
+	issues := deny_remote_source with terraform.module_calls as mock_module_calls
 
-  count(issues) == 1
-  issue := issues[_]
-  issue.msg == "remote module is not allowed"
+	count(issues) == 1
+	issue := issues[_]
+	issue.msg == "remote module is not allowed"
 }
 
 test_deny_remote_source_failed if {
-  issues := deny_remote_source with terraform.module_calls as mock_module_calls
+	issues := deny_remote_source with terraform.module_calls as mock_module_calls
 
-  count(issues) == 0
+	count(issues) == 0
 }

--- a/integration/module_calls/result.json
+++ b/integration/module_calls/result.json
@@ -4,7 +4,7 @@
       "rule": {
         "name": "opa_deny_remote_source",
         "severity": "error",
-        "link": "policies/main.rego:3"
+        "link": "policies/main.rego:5"
       },
       "message": "remote module is not allowed",
       "range": {

--- a/integration/module_calls/result_test.json
+++ b/integration/module_calls/result_test.json
@@ -4,7 +4,7 @@
       "rule": {
         "name": "opa_test_deny_remote_source_failed",
         "severity": "error",
-        "link": "policies/main_test.rego:17"
+        "link": "policies/main_test.rego:18"
       },
       "message": "test failed",
       "range": {

--- a/integration/moved/policies/main.rego
+++ b/integration/moved/policies/main.rego
@@ -1,8 +1,10 @@
 package tflint
 
-deny_moved_blocks[issue] {
-  moved := terraform.moved_blocks({}, {})
-  count(moved) > 0
+import rego.v1
 
-  issue := tflint.issue("moved blocks are not allowed", moved[0].decl_range)
+deny_moved_blocks contains issue if {
+	moved := terraform.moved_blocks({}, {})
+	count(moved) > 0
+
+	issue := tflint.issue("moved blocks are not allowed", moved[0].decl_range)
 }

--- a/integration/moved/policies/main_test.rego
+++ b/integration/moved/policies/main_test.rego
@@ -1,5 +1,6 @@
 package tflint
-import future.keywords
+
+import rego.v1
 
 mock_moved_blocks(schema, options) := terraform.mock_moved_blocks(schema, options, {"main.tf": `
 moved {
@@ -8,15 +9,15 @@ moved {
 }`})
 
 test_deny_moved_blocks_passed if {
-  issues := deny_moved_blocks with terraform.moved_blocks as mock_moved_blocks
+	issues := deny_moved_blocks with terraform.moved_blocks as mock_moved_blocks
 
-  count(issues) == 1
-  issue := issues[_]
-  issue.msg == "moved blocks are not allowed"
+	count(issues) == 1
+	issue := issues[_]
+	issue.msg == "moved blocks are not allowed"
 }
 
 test_deny_moved_blocks_failed if {
-  issues := deny_moved_blocks with terraform.moved_blocks as mock_moved_blocks
+	issues := deny_moved_blocks with terraform.moved_blocks as mock_moved_blocks
 
-  count(issues) == 0
+	count(issues) == 0
 }

--- a/integration/moved/result.json
+++ b/integration/moved/result.json
@@ -4,7 +4,7 @@
       "rule": {
         "name": "opa_deny_moved_blocks",
         "severity": "error",
-        "link": "policies/main.rego:3"
+        "link": "policies/main.rego:5"
       },
       "message": "moved blocks are not allowed",
       "range": {

--- a/integration/moved/result_test.json
+++ b/integration/moved/result_test.json
@@ -4,7 +4,7 @@
       "rule": {
         "name": "opa_test_deny_moved_blocks_failed",
         "severity": "error",
-        "link": "policies/main_test.rego:18"
+        "link": "policies/main_test.rego:19"
       },
       "message": "test failed",
       "range": {

--- a/integration/naming_convention/policies/main.rego
+++ b/integration/naming_convention/policies/main.rego
@@ -1,8 +1,10 @@
 package tflint
 
-deny_not_snake_case[issue] {
-  resources := terraform.resources("*", {}, {})
-  not regex.match("^[a-z][a-z0-9]*(_[a-z0-9]+)*$", resources[i].name)
+import rego.v1
 
-  issue := tflint.issue(sprintf("%s is not snake case", [resources[i].name]), resources[i].decl_range)
+deny_not_snake_case contains issue if {
+	resources := terraform.resources("*", {}, {})
+	not regex.match("^[a-z][a-z0-9]*(_[a-z0-9]+)*$", resources[i].name)
+
+	issue := tflint.issue(sprintf("%s is not snake case", [resources[i].name]), resources[i].decl_range)
 }

--- a/integration/naming_convention/policies/main_test.rego
+++ b/integration/naming_convention/policies/main_test.rego
@@ -1,23 +1,22 @@
 package tflint
-import future.keywords
+
+import rego.v1
 
 mock_resources(type, schema, options) := terraform.mock_resources(type, schema, options, {"main.tf": `
 resource "aws_instance" "main-v2" {}
 `})
 
 test_deny_not_snake_case_passed if {
-  issues := deny_not_snake_case
-    with terraform.resources as mock_resources
+	issues := deny_not_snake_case with terraform.resources as mock_resources
 
-  count(issues) == 1
-  issue := issues[_]
-  issue.msg == "main-v2 is not snake case"
-  issue.range.start.line == 2
+	count(issues) == 1
+	issue := issues[_]
+	issue.msg == "main-v2 is not snake case"
+	issue.range.start.line == 2
 }
 
 test_deny_not_snake_case_failed if {
-  issues := deny_not_snake_case
-    with terraform.resources as mock_resources
+	issues := deny_not_snake_case with terraform.resources as mock_resources
 
-  count(issues) == 0
+	count(issues) == 0
 }

--- a/integration/naming_convention/result.json
+++ b/integration/naming_convention/result.json
@@ -4,7 +4,7 @@
       "rule": {
         "name": "opa_deny_not_snake_case",
         "severity": "error",
-        "link": "policies/main.rego:3"
+        "link": "policies/main.rego:5"
       },
       "message": "invalid-name is not snake case",
       "range": {
@@ -24,7 +24,7 @@
       "rule": {
         "name": "opa_deny_not_snake_case",
         "severity": "error",
-        "link": "policies/main.rego:3"
+        "link": "policies/main.rego:5"
       },
       "message": "invalid-name is not snake case",
       "range": {

--- a/integration/outputs/policies/main.rego
+++ b/integration/outputs/policies/main.rego
@@ -1,8 +1,10 @@
 package tflint
 
-deny_no_outputs[issue] {
-  outputs := terraform.outputs({}, {})
-  count(outputs) == 0
+import rego.v1
 
-  issue := tflint.issue("module must expose outputs", terraform.module_range())
+deny_no_outputs contains issue if {
+	outputs := terraform.outputs({}, {})
+	count(outputs) == 0
+
+	issue := tflint.issue("module must expose outputs", terraform.module_range())
 }

--- a/integration/outputs/policies/main_test.rego
+++ b/integration/outputs/policies/main_test.rego
@@ -1,19 +1,20 @@
 package tflint
-import future.keywords
+
+import rego.v1
 
 mock_outputs(schema, options) := terraform.mock_outputs(schema, options, {})
 
 test_deny_no_outputs_passed if {
-  issues := deny_no_outputs with terraform.outputs as mock_outputs
+	issues := deny_no_outputs with terraform.outputs as mock_outputs
 
-  count(issues) == 1
-  issue := issues[_]
-  issue.msg == "module must expose outputs"
-  issue.range.start.line == 1
+	count(issues) == 1
+	issue := issues[_]
+	issue.msg == "module must expose outputs"
+	issue.range.start.line == 1
 }
 
 test_deny_no_outputs_failed if {
-  issues := deny_no_outputs with terraform.outputs as mock_outputs
+	issues := deny_no_outputs with terraform.outputs as mock_outputs
 
-  count(issues) == 0
+	count(issues) == 0
 }

--- a/integration/outputs/result.json
+++ b/integration/outputs/result.json
@@ -4,7 +4,7 @@
       "rule": {
         "name": "opa_deny_no_outputs",
         "severity": "error",
-        "link": "policies/main.rego:3"
+        "link": "policies/main.rego:5"
       },
       "message": "module must expose outputs",
       "range": {

--- a/integration/outputs/result_test.json
+++ b/integration/outputs/result_test.json
@@ -4,7 +4,7 @@
       "rule": {
         "name": "opa_test_deny_no_outputs_failed",
         "severity": "error",
-        "link": "policies/main_test.rego:15"
+        "link": "policies/main_test.rego:16"
       },
       "message": "test failed",
       "range": {

--- a/integration/providers/policies/main.rego
+++ b/integration/providers/policies/main.rego
@@ -1,17 +1,19 @@
 package tflint
 
-deny_us_east_1[issue] {
-  providers := terraform.providers({"region": "string"}, {})
-  region := providers[_].config.region
+import rego.v1
 
-  region.value == "us-east-1"
+deny_us_east_1 contains issue if {
+	providers := terraform.providers({"region": "string"}, {})
+	region := providers[_].config.region
 
-  issue := tflint.issue("us-east-1 is not allowed", region.range)
+	region.value == "us-east-1"
+
+	issue := tflint.issue("us-east-1 is not allowed", region.range)
 }
 
-deny_provider_ref[issue] {
-  resources := terraform.resources("*", {"provider": "any"}, {})
-  provider := resources[_].config.provider
+deny_provider_ref contains issue if {
+	resources := terraform.resources("*", {"provider": "any"}, {})
+	provider := resources[_].config.provider
 
-  issue := tflint.issue("provider reference is not allowed", provider.range)
+	issue := tflint.issue("provider reference is not allowed", provider.range)
 }

--- a/integration/providers/policies/main_test.rego
+++ b/integration/providers/policies/main_test.rego
@@ -1,5 +1,6 @@
 package tflint
-import future.keywords
+
+import rego.v1
 
 mock_providers(schema, options) := terraform.mock_providers(schema, options, {"main.tf": `
 provider "aws" {
@@ -8,15 +9,15 @@ provider "aws" {
 }`})
 
 test_deny_us_east_1_passed if {
-  issues := deny_us_east_1 with terraform.providers as mock_providers
+	issues := deny_us_east_1 with terraform.providers as mock_providers
 
-  count(issues) == 1
-  issue := issues[_]
-  issue.msg == "us-east-1 is not allowed"
+	count(issues) == 1
+	issue := issues[_]
+	issue.msg == "us-east-1 is not allowed"
 }
 
 test_deny_us_east_1_failed if {
-  issues := deny_us_east_1 with terraform.providers as mock_providers
+	issues := deny_us_east_1 with terraform.providers as mock_providers
 
-  count(issues) == 0
+	count(issues) == 0
 }

--- a/integration/providers/result.json
+++ b/integration/providers/result.json
@@ -4,7 +4,7 @@
       "rule": {
         "name": "opa_deny_us_east_1",
         "severity": "error",
-        "link": "policies/main.rego:3"
+        "link": "policies/main.rego:5"
       },
       "message": "us-east-1 is not allowed",
       "range": {
@@ -24,7 +24,7 @@
       "rule": {
         "name": "opa_deny_provider_ref",
         "severity": "error",
-        "link": "policies/main.rego:12"
+        "link": "policies/main.rego:14"
       },
       "message": "provider reference is not allowed",
       "range": {

--- a/integration/providers/result_test.json
+++ b/integration/providers/result_test.json
@@ -4,7 +4,7 @@
       "rule": {
         "name": "opa_test_deny_us_east_1_failed",
         "severity": "error",
-        "link": "policies/main_test.rego:18"
+        "link": "policies/main_test.rego:19"
       },
       "message": "test failed",
       "range": {

--- a/integration/removed/policies/main.rego
+++ b/integration/removed/policies/main.rego
@@ -1,8 +1,10 @@
 package tflint
 
-deny_removed_blocks[issue] {
-  moved := terraform.removed_blocks({}, {})
-  count(moved) > 0
+import rego.v1
 
-  issue := tflint.issue("removed blocks are not allowed", moved[0].decl_range)
+deny_removed_blocks contains issue if {
+	moved := terraform.removed_blocks({}, {})
+	count(moved) > 0
+
+	issue := tflint.issue("removed blocks are not allowed", moved[0].decl_range)
 }

--- a/integration/removed/policies/main_test.rego
+++ b/integration/removed/policies/main_test.rego
@@ -1,5 +1,6 @@
 package tflint
-import future.keywords
+
+import rego.v1
 
 mock_removed_blocks(schema, options) := terraform.mock_removed_blocks(schema, options, {"main.tf": `
 removed {
@@ -11,15 +12,15 @@ removed {
 }`})
 
 test_deny_removed_blocks_passed if {
-  issues := deny_removed_blocks with terraform.removed_blocks as mock_removed_blocks
+	issues := deny_removed_blocks with terraform.removed_blocks as mock_removed_blocks
 
-  count(issues) == 1
-  issue := issues[_]
-  issue.msg == "removed blocks are not allowed"
+	count(issues) == 1
+	issue := issues[_]
+	issue.msg == "removed blocks are not allowed"
 }
 
 test_deny_removed_blocks_failed if {
-  issues := deny_removed_blocks with terraform.removed_blocks as mock_removed_blocks
+	issues := deny_removed_blocks with terraform.removed_blocks as mock_removed_blocks
 
-  count(issues) == 0
+	count(issues) == 0
 }

--- a/integration/removed/result.json
+++ b/integration/removed/result.json
@@ -4,7 +4,7 @@
       "rule": {
         "name": "opa_deny_removed_blocks",
         "severity": "error",
-        "link": "policies/main.rego:3"
+        "link": "policies/main.rego:5"
       },
       "message": "removed blocks are not allowed",
       "range": {

--- a/integration/removed/result_test.json
+++ b/integration/removed/result_test.json
@@ -4,7 +4,7 @@
       "rule": {
         "name": "opa_test_deny_removed_blocks_failed",
         "severity": "error",
-        "link": "policies/main_test.rego:21"
+        "link": "policies/main_test.rego:22"
       },
       "message": "test failed",
       "range": {

--- a/integration/resources/policies/main.rego
+++ b/integration/resources/policies/main.rego
@@ -1,15 +1,17 @@
 package tflint
 
-deny_all_resources[issue] {
-  resources := terraform.resources("*", {}, {})
-  count(resources) > 0
+import rego.v1
 
-  issue := tflint.issue("resource is not allowed", resources[0].decl_range)
+deny_all_resources contains issue if {
+	resources := terraform.resources("*", {}, {})
+	count(resources) > 0
+
+	issue := tflint.issue("resource is not allowed", resources[0].decl_range)
 }
 
-deny_no_resources[issue] {
-  resources := terraform.resources("*", {}, {})
-  count(resources) == 0
+deny_no_resources contains issue if {
+	resources := terraform.resources("*", {}, {})
+	count(resources) == 0
 
-  issue := tflint.issue("resources should be declared", terraform.module_range())
+	issue := tflint.issue("resources should be declared", terraform.module_range())
 }

--- a/integration/resources/policies/main_test.rego
+++ b/integration/resources/policies/main_test.rego
@@ -1,36 +1,37 @@
 package tflint
-import future.keywords
+
+import rego.v1
 
 mock_resources(type, schema, options) := terraform.mock_resources(type, schema, options, {"main.tf": `
 resource "aws_instance" "main" {}
 `})
 
 test_deny_all_resources_passed if {
-  issues := deny_all_resources with terraform.resources as mock_resources
+	issues := deny_all_resources with terraform.resources as mock_resources
 
-  count(issues) == 1
-  issue := issues[_]
-  issue.msg == "resource is not allowed"
+	count(issues) == 1
+	issue := issues[_]
+	issue.msg == "resource is not allowed"
 }
 
 test_deny_all_resources_failed if {
-  issues := deny_all_resources with terraform.resources as mock_resources
+	issues := deny_all_resources with terraform.resources as mock_resources
 
-  count(issues) == 0
+	count(issues) == 0
 }
 
 mock_no_resources(type, schema, options) := terraform.mock_resources(type, schema, options, {})
 
 test_deny_no_resources_passed if {
-  issues := deny_no_resources with terraform.resources as mock_no_resources
+	issues := deny_no_resources with terraform.resources as mock_no_resources
 
-  count(issues) == 1
-  issue := issues[_]
-  issue.msg == "resources should be declared"
+	count(issues) == 1
+	issue := issues[_]
+	issue.msg == "resources should be declared"
 }
 
 test_deny_no_resources_failed if {
-  issues := deny_no_resources with terraform.resources as mock_no_resources
+	issues := deny_no_resources with terraform.resources as mock_no_resources
 
-  count(issues) == 0
+	count(issues) == 0
 }

--- a/integration/resources/result.json
+++ b/integration/resources/result.json
@@ -4,7 +4,7 @@
       "rule": {
         "name": "opa_deny_no_resources",
         "severity": "error",
-        "link": "policies/main.rego:10"
+        "link": "policies/main.rego:12"
       },
       "message": "resources should be declared",
       "range": {

--- a/integration/settings/policies/main.rego
+++ b/integration/settings/policies/main.rego
@@ -1,10 +1,12 @@
 package tflint
 
-deny_default_hostname[issue] {
-  settings := terraform.settings({"cloud": {"hostname": "string"}}, {})
-  hostname := settings[_].config.cloud[_].config.hostname
+import rego.v1
 
-  hostname.value == "app.terraform.io"
+deny_default_hostname contains issue if {
+	settings := terraform.settings({"cloud": {"hostname": "string"}}, {})
+	hostname := settings[_].config.cloud[_].config.hostname
 
-  issue := tflint.issue("default hostname should be omitted", hostname.range)
+	hostname.value == "app.terraform.io"
+
+	issue := tflint.issue("default hostname should be omitted", hostname.range)
 }

--- a/integration/settings/policies/main_test.rego
+++ b/integration/settings/policies/main_test.rego
@@ -1,5 +1,6 @@
 package tflint
-import future.keywords
+
+import rego.v1
 
 mock_settings(schema, options) := terraform.mock_settings(schema, options, {"main.tf": `
 terraform {
@@ -9,15 +10,15 @@ terraform {
 }`})
 
 test_deny_default_hostname_passed if {
-  issues := deny_default_hostname with terraform.settings as mock_settings
+	issues := deny_default_hostname with terraform.settings as mock_settings
 
-  count(issues) == 1
-  issue := issues[_]
-  issue.msg == "default hostname should be omitted"
+	count(issues) == 1
+	issue := issues[_]
+	issue.msg == "default hostname should be omitted"
 }
 
 test_deny_default_hostname_failed if {
-  issues := deny_default_hostname with terraform.settings as mock_settings
+	issues := deny_default_hostname with terraform.settings as mock_settings
 
-  count(issues) == 0
+	count(issues) == 0
 }

--- a/integration/settings/result.json
+++ b/integration/settings/result.json
@@ -4,7 +4,7 @@
       "rule": {
         "name": "opa_deny_default_hostname",
         "severity": "error",
-        "link": "policies/main.rego:3"
+        "link": "policies/main.rego:5"
       },
       "message": "default hostname should be omitted",
       "range": {

--- a/integration/settings/result_test.json
+++ b/integration/settings/result_test.json
@@ -4,7 +4,7 @@
       "rule": {
         "name": "opa_test_deny_default_hostname_failed",
         "severity": "error",
-        "link": "policies/main_test.rego:19"
+        "link": "policies/main_test.rego:20"
       },
       "message": "test failed",
       "range": {

--- a/integration/tagged/policies/main.rego
+++ b/integration/tagged/policies/main.rego
@@ -1,24 +1,25 @@
 package tflint
 
-contains(array, elem) {
-  array[_] = elem
-}
-is_not_tagged(config) {
-  is_null(config.tags.value)
-}
-is_not_tagged(config) {
-  not is_null(config.tags.value)
-  not contains(object.keys(config.tags.value), "Environment")
-}
-is_not_tagged(config) {
-  not contains(object.keys(config), "tags")
+import rego.v1
+
+is_not_tagged(config) if {
+	is_null(config.tags.value)
 }
 
-deny_not_tagged_instance[issue] {
-  resources := terraform.resources("aws_instance", {"tags": "map(string)"}, {})
-  resource := resources[_]
+is_not_tagged(config) if {
+	not is_null(config.tags.value)
+	not "Environment" in object.keys(config.tags.value)
+}
 
-  is_not_tagged(resource.config)
+is_not_tagged(config) if {
+	not "tags" in object.keys(config)
+}
 
-  issue := tflint.issue("instance should be tagged with Environment", resource.decl_range)
+deny_not_tagged_instance contains issue if {
+	resources := terraform.resources("aws_instance", {"tags": "map(string)"}, {})
+	resource := resources[_]
+
+	is_not_tagged(resource.config)
+
+	issue := tflint.issue("instance should be tagged with Environment", resource.decl_range)
 }

--- a/integration/tagged/policies/main_test.rego
+++ b/integration/tagged/policies/main_test.rego
@@ -1,5 +1,6 @@
 package tflint
-import future.keywords
+
+import rego.v1
 
 mock_resources_not_tagged(type, schema, options) := terraform.mock_resources(type, schema, options, {"main.tf": `
 resource "aws_instance" "main" {
@@ -9,17 +10,17 @@ resource "aws_instance" "main" {
 }`})
 
 test_deny_not_tagged_instance_passed if {
-  issues := deny_not_tagged_instance with terraform.resources as mock_resources_not_tagged
+	issues := deny_not_tagged_instance with terraform.resources as mock_resources_not_tagged
 
-  count(issues) == 1
-  issue := issues[_]
-  issue.msg == "instance should be tagged with Environment"
+	count(issues) == 1
+	issue := issues[_]
+	issue.msg == "instance should be tagged with Environment"
 }
 
 test_deny_not_tagged_instance_failed if {
-  issues := deny_not_tagged_instance with terraform.resources as mock_resources_not_tagged
+	issues := deny_not_tagged_instance with terraform.resources as mock_resources_not_tagged
 
-  count(issues) == 0
+	count(issues) == 0
 }
 
 mock_resources_no_tags(type, schema, options) := terraform.mock_resources(type, schema, options, {"main.tf": `
@@ -27,17 +28,17 @@ resource "aws_instance" "main" {
 }`})
 
 test_deny_not_tagged_instance_without_tags_passed if {
-  issues := deny_not_tagged_instance with terraform.resources as mock_resources_no_tags
+	issues := deny_not_tagged_instance with terraform.resources as mock_resources_no_tags
 
-  count(issues) == 1
-  issue := issues[_]
-  issue.msg == "instance should be tagged with Environment"
+	count(issues) == 1
+	issue := issues[_]
+	issue.msg == "instance should be tagged with Environment"
 }
 
 test_deny_not_tagged_instance_without_tags_failed if {
-  issues := deny_not_tagged_instance with terraform.resources as mock_resources_no_tags
+	issues := deny_not_tagged_instance with terraform.resources as mock_resources_no_tags
 
-  count(issues) == 0
+	count(issues) == 0
 }
 
 mock_resources_null_tags(type, schema, options) := terraform.mock_resources(type, schema, options, {"main.tf": `
@@ -46,15 +47,15 @@ resource "aws_instance" "main" {
 }`})
 
 test_deny_not_tagged_instance_null_tags_passed if {
-  issues := deny_not_tagged_instance with terraform.resources as mock_resources_null_tags
+	issues := deny_not_tagged_instance with terraform.resources as mock_resources_null_tags
 
-  count(issues) == 1
-  issue := issues[_]
-  issue.msg == "instance should be tagged with Environment"
+	count(issues) == 1
+	issue := issues[_]
+	issue.msg == "instance should be tagged with Environment"
 }
 
 test_deny_not_tagged_instance_null_tags_failed if {
-  issues := deny_not_tagged_instance with terraform.resources as mock_resources_null_tags
+	issues := deny_not_tagged_instance with terraform.resources as mock_resources_null_tags
 
-  count(issues) == 0
+	count(issues) == 0
 }

--- a/integration/tagged/result.json
+++ b/integration/tagged/result.json
@@ -4,7 +4,7 @@
 			"rule": {
 				"name": "opa_deny_not_tagged_instance",
 				"severity": "error",
-				"link": "policies/main.rego:17"
+				"link": "policies/main.rego:18"
 			},
 			"message": "instance should be tagged with Environment",
 			"range": {
@@ -24,7 +24,7 @@
 			"rule": {
 				"name": "opa_deny_not_tagged_instance",
 				"severity": "error",
-				"link": "policies/main.rego:17"
+				"link": "policies/main.rego:18"
 			},
 			"message": "instance should be tagged with Environment",
 			"range": {
@@ -44,7 +44,7 @@
 			"rule": {
 				"name": "opa_deny_not_tagged_instance",
 				"severity": "error",
-				"link": "policies/main.rego:17"
+				"link": "policies/main.rego:18"
 			},
 			"message": "instance should be tagged with Environment",
 			"range": {

--- a/integration/tagged/result_test.json
+++ b/integration/tagged/result_test.json
@@ -4,7 +4,7 @@
       "rule": {
         "name": "opa_test_deny_not_tagged_instance_failed",
         "severity": "error",
-        "link": "policies/main_test.rego:19"
+        "link": "policies/main_test.rego:20"
       },
       "message": "test failed",
       "range": {
@@ -24,7 +24,7 @@
       "rule": {
         "name": "opa_test_deny_not_tagged_instance_without_tags_failed",
         "severity": "error",
-        "link": "policies/main_test.rego:37"
+        "link": "policies/main_test.rego:38"
       },
       "message": "test failed",
       "range": {
@@ -44,7 +44,7 @@
       "rule": {
         "name": "opa_test_deny_not_tagged_instance_null_tags_failed",
         "severity": "error",
-        "link": "policies/main_test.rego:56"
+        "link": "policies/main_test.rego:57"
       },
       "message": "test failed",
       "range": {

--- a/integration/variables/policies/main.rego
+++ b/integration/variables/policies/main.rego
@@ -1,10 +1,12 @@
 package tflint
 
-deny_empty_description[issue] {
-  vars := terraform.variables({"description": "string"}, {})
-  description := vars[_].config.description
-  
-  description.value == ""
+import rego.v1
 
-  issue := tflint.issue("empty description is not allowed", description.range)
+deny_empty_description contains issue if {
+	vars := terraform.variables({"description": "string"}, {})
+	description := vars[_].config.description
+
+	description.value == ""
+
+	issue := tflint.issue("empty description is not allowed", description.range)
 }

--- a/integration/variables/policies/main_test.rego
+++ b/integration/variables/policies/main_test.rego
@@ -1,5 +1,6 @@
 package tflint
-import future.keywords
+
+import rego.v1
 
 mock_variables(schema, options) := terraform.mock_variables(schema, options, {"main.tf": `
 variable "foo" {
@@ -7,15 +8,15 @@ variable "foo" {
 }`})
 
 test_deny_empty_description_passed if {
-  issues := deny_empty_description with terraform.variables as mock_variables
+	issues := deny_empty_description with terraform.variables as mock_variables
 
-  count(issues) == 1
-  issue := issues[_]
-  issue.msg == "empty description is not allowed"
+	count(issues) == 1
+	issue := issues[_]
+	issue.msg == "empty description is not allowed"
 }
 
 test_deny_empty_description_failed if {
-  issues := deny_empty_description with terraform.variables as mock_variables
+	issues := deny_empty_description with terraform.variables as mock_variables
 
-  count(issues) == 0
+	count(issues) == 0
 }

--- a/integration/variables/result.json
+++ b/integration/variables/result.json
@@ -4,7 +4,7 @@
       "rule": {
         "name": "opa_deny_empty_description",
         "severity": "error",
-        "link": "policies/main.rego:3"
+        "link": "policies/main.rego:5"
       },
       "message": "empty description is not allowed",
       "range": {

--- a/integration/variables/result_test.json
+++ b/integration/variables/result_test.json
@@ -4,7 +4,7 @@
       "rule": {
         "name": "opa_test_deny_empty_description_failed",
         "severity": "error",
-        "link": "policies/main_test.rego:17"
+        "link": "policies/main_test.rego:18"
       },
       "message": "test failed",
       "range": {

--- a/integration/volume_size/policies/main.rego
+++ b/integration/volume_size/policies/main.rego
@@ -1,9 +1,11 @@
 package tflint
 
-deny_large_volume[issue] {
-  resources := terraform.resources("aws_instance", {"ebs_block_device": {"volume_size": "number"}}, {})
-  volume_size := resources[_].config.ebs_block_device[_].config.volume_size
-  volume_size.value > 30
+import rego.v1
 
-  issue := tflint.issue("volume size should be 30GB or less", volume_size.range)
+deny_large_volume contains issue if {
+	resources := terraform.resources("aws_instance", {"ebs_block_device": {"volume_size": "number"}}, {})
+	volume_size := resources[_].config.ebs_block_device[_].config.volume_size
+	volume_size.value > 30
+
+	issue := tflint.issue("volume size should be 30GB or less", volume_size.range)
 }

--- a/integration/volume_size/policies/main_test.rego
+++ b/integration/volume_size/policies/main_test.rego
@@ -1,5 +1,6 @@
 package tflint
-import future.keywords
+
+import rego.v1
 
 mock_resources_50gb(type, schema, options) := terraform.mock_resources(type, schema, options, {"main.tf": `
 resource "aws_instance" "main" {
@@ -9,17 +10,17 @@ resource "aws_instance" "main" {
 }`})
 
 test_deny_large_volume_passed if {
-  issues := deny_large_volume with terraform.resources as mock_resources_50gb
+	issues := deny_large_volume with terraform.resources as mock_resources_50gb
 
-  count(issues) == 1
-  issue := issues[_]
-  issue.msg == "volume size should be 30GB or less"
+	count(issues) == 1
+	issue := issues[_]
+	issue.msg == "volume size should be 30GB or less"
 }
 
 test_deny_large_volume_failed if {
-  issues := deny_large_volume with terraform.resources as mock_resources_50gb
+	issues := deny_large_volume with terraform.resources as mock_resources_50gb
 
-  count(issues) == 0
+	count(issues) == 0
 }
 
 mock_resources_50gb_string(type, schema, options) := terraform.mock_resources(type, schema, options, {"main.tf": `
@@ -30,17 +31,17 @@ resource "aws_instance" "main" {
 }`})
 
 test_deny_large_volume_string_passed if {
-  issues := deny_large_volume with terraform.resources as mock_resources_50gb_string
+	issues := deny_large_volume with terraform.resources as mock_resources_50gb_string
 
-  count(issues) == 1
-  issue := issues[_]
-  issue.msg == "volume size should be 30GB or less"
+	count(issues) == 1
+	issue := issues[_]
+	issue.msg == "volume size should be 30GB or less"
 }
 
 test_deny_large_volume_string_failed if {
-  issues := deny_large_volume with terraform.resources as mock_resources_50gb_string
+	issues := deny_large_volume with terraform.resources as mock_resources_50gb_string
 
-  count(issues) == 0
+	count(issues) == 0
 }
 
 mock_resources_30_5gb(type, schema, options) := terraform.mock_resources(type, schema, options, {"main.tf": `
@@ -51,15 +52,15 @@ resource "aws_instance" "main" {
 }`})
 
 test_deny_large_volume_float_passed if {
-  issues := deny_large_volume with terraform.resources as mock_resources_30_5gb
+	issues := deny_large_volume with terraform.resources as mock_resources_30_5gb
 
-  count(issues) == 1
-  issue := issues[_]
-  issue.msg == "volume size should be 30GB or less"
+	count(issues) == 1
+	issue := issues[_]
+	issue.msg == "volume size should be 30GB or less"
 }
 
 test_deny_large_volume_float_failed if {
-  issues := deny_large_volume with terraform.resources as mock_resources_30_5gb
+	issues := deny_large_volume with terraform.resources as mock_resources_30_5gb
 
-  count(issues) == 0
+	count(issues) == 0
 }

--- a/integration/volume_size/result.json
+++ b/integration/volume_size/result.json
@@ -4,7 +4,7 @@
       "rule": {
         "name": "opa_deny_large_volume",
         "severity": "error",
-        "link": "policies/main.rego:3"
+        "link": "policies/main.rego:5"
       },
       "message": "volume size should be 30GB or less",
       "range": {
@@ -24,7 +24,7 @@
       "rule": {
         "name": "opa_deny_large_volume",
         "severity": "error",
-        "link": "policies/main.rego:3"
+        "link": "policies/main.rego:5"
       },
       "message": "volume size should be 30GB or less",
       "range": {
@@ -44,7 +44,7 @@
       "rule": {
         "name": "opa_deny_large_volume",
         "severity": "error",
-        "link": "policies/main.rego:3"
+        "link": "policies/main.rego:5"
       },
       "message": "volume size should be 30GB or less",
       "range": {

--- a/integration/volume_size/result_test.json
+++ b/integration/volume_size/result_test.json
@@ -4,7 +4,7 @@
       "rule": {
         "name": "opa_test_deny_large_volume_failed",
         "severity": "error",
-        "link": "policies/main_test.rego:19"
+        "link": "policies/main_test.rego:20"
       },
       "message": "test failed",
       "range": {
@@ -24,7 +24,7 @@
       "rule": {
         "name": "opa_test_deny_large_volume_string_failed",
         "severity": "error",
-        "link": "policies/main_test.rego:40"
+        "link": "policies/main_test.rego:41"
       },
       "message": "test failed",
       "range": {
@@ -44,7 +44,7 @@
       "rule": {
         "name": "opa_test_deny_large_volume_float_failed",
         "severity": "error",
-        "link": "policies/main_test.rego:61"
+        "link": "policies/main_test.rego:62"
       },
       "message": "test failed",
       "range": {

--- a/integration/volume_type/policies/main.rego
+++ b/integration/volume_type/policies/main.rego
@@ -1,28 +1,30 @@
 package tflint
 
-warn_gp3_volume[issue] {
-  resources := terraform.resources("aws_instance", {"count": "number"}, {"expand_mode": "none"})
-  count := resources[_].config.count
+import rego.v1
 
-  count.unknown == true
+warn_gp3_volume contains issue if {
+	resources := terraform.resources("aws_instance", {"count": "number"}, {"expand_mode": "none"})
+	count := resources[_].config.count
 
-  issue := tflint.issue("unknown resource found", count.range)
+	count.unknown == true
+
+	issue := tflint.issue("unknown resource found", count.range)
 }
 
-warn_gp3_volume[issue] {
-  resources := terraform.resources("aws_instance", {"dynamic": {"__labels": ["name"], "for_each": "any"}}, {"expand_mode": "none"})
-  for_each := resources[_].config.dynamic[_].config.for_each
+warn_gp3_volume contains issue if {
+	resources := terraform.resources("aws_instance", {"dynamic": {"__labels": ["name"], "for_each": "any"}}, {"expand_mode": "none"})
+	for_each := resources[_].config.dynamic[_].config.for_each
 
-  for_each.unknown == true
+	for_each.unknown == true
 
-  issue := tflint.issue("unknown block found", for_each.range)
+	issue := tflint.issue("unknown block found", for_each.range)
 }
 
-warn_gp3_volume[issue] {
-  resources := terraform.resources("aws_instance", {"ebs_block_device": {"volume_type": "string"}}, {})
-  volume_type := resources[_].config.ebs_block_device[_].config.volume_type
+warn_gp3_volume contains issue if {
+	resources := terraform.resources("aws_instance", {"ebs_block_device": {"volume_type": "string"}}, {})
+	volume_type := resources[_].config.ebs_block_device[_].config.volume_type
 
-  volume_type.value == "gp3"
+	volume_type.value == "gp3"
 
-  issue := tflint.issue("gp3 is not allowed", volume_type.range)
+	issue := tflint.issue("gp3 is not allowed", volume_type.range)
 }

--- a/integration/volume_type/policies/main_test.rego
+++ b/integration/volume_type/policies/main_test.rego
@@ -1,5 +1,6 @@
 package tflint
-import future.keywords
+
+import rego.v1
 
 mock_resources_gp3(type, schema, options) := terraform.mock_resources(type, schema, options, {"main.tf": `
 resource "aws_instance" "main" {
@@ -9,17 +10,17 @@ resource "aws_instance" "main" {
 }`})
 
 test_warn_gp3_volume_passed if {
-  issues := warn_gp3_volume with terraform.resources as mock_resources_gp3
+	issues := warn_gp3_volume with terraform.resources as mock_resources_gp3
 
-  count(issues) == 1
-  issue := issues[_]
-  issue.msg == "gp3 is not allowed"
+	count(issues) == 1
+	issue := issues[_]
+	issue.msg == "gp3 is not allowed"
 }
 
 test_warn_gp3_volume_failed if {
-  issues := warn_gp3_volume with terraform.resources as mock_resources_gp3
+	issues := warn_gp3_volume with terraform.resources as mock_resources_gp3
 
-  count(issues) == 0
+	count(issues) == 0
 }
 
 mock_resources_unknown_dynamic(type, schema, options) := terraform.mock_resources(type, schema, options, {"main.tf": `
@@ -36,15 +37,15 @@ resource "aws_instance" "main" {
 }`})
 
 test_warn_gp3_volume_unknown_dynamic_passed if {
-  issues := warn_gp3_volume with terraform.resources as mock_resources_unknown_dynamic
+	issues := warn_gp3_volume with terraform.resources as mock_resources_unknown_dynamic
 
-  count(issues) == 1
-  issue := issues[_]
-  issue.msg == "unknown block found"
+	count(issues) == 1
+	issue := issues[_]
+	issue.msg == "unknown block found"
 }
 
 test_warn_gp3_volume_unknown_dynamic_failed if {
-  issues := warn_gp3_volume with terraform.resources as mock_resources_unknown_dynamic
+	issues := warn_gp3_volume with terraform.resources as mock_resources_unknown_dynamic
 
-  count(issues) == 0
+	count(issues) == 0
 }

--- a/integration/volume_type/result.json
+++ b/integration/volume_type/result.json
@@ -4,7 +4,7 @@
       "rule": {
         "name": "opa_warn_gp3_volume",
         "severity": "warning",
-        "link": "policies/main.rego:3"
+        "link": "policies/main.rego:5"
       },
       "message": "gp3 is not allowed",
       "range": {
@@ -24,7 +24,7 @@
       "rule": {
         "name": "opa_warn_gp3_volume",
         "severity": "warning",
-        "link": "policies/main.rego:3"
+        "link": "policies/main.rego:5"
       },
       "message": "gp3 is not allowed",
       "range": {
@@ -44,7 +44,7 @@
       "rule": {
         "name": "opa_warn_gp3_volume",
         "severity": "warning",
-        "link": "policies/main.rego:3"
+        "link": "policies/main.rego:5"
       },
       "message": "unknown block found",
       "range": {
@@ -64,7 +64,7 @@
       "rule": {
         "name": "opa_warn_gp3_volume",
         "severity": "warning",
-        "link": "policies/main.rego:3"
+        "link": "policies/main.rego:5"
       },
       "message": "unknown resource found",
       "range": {

--- a/integration/volume_type/result_test.json
+++ b/integration/volume_type/result_test.json
@@ -4,7 +4,7 @@
       "rule": {
         "name": "opa_test_warn_gp3_volume_failed",
         "severity": "error",
-        "link": "policies/main_test.rego:19"
+        "link": "policies/main_test.rego:20"
       },
       "message": "test failed",
       "range": {
@@ -24,7 +24,7 @@
       "rule": {
         "name": "opa_test_warn_gp3_volume_unknown_dynamic_failed",
         "severity": "error",
-        "link": "policies/main_test.rego:46"
+        "link": "policies/main_test.rego:47"
       },
       "message": "test failed",
       "range": {

--- a/opa/engine_test.go
+++ b/opa/engine_test.go
@@ -26,7 +26,9 @@ func TestRunQuery(t *testing.T) {
 				"main.rego": `
 package tflint
 
-deny_test[issue] {
+import rego.v1
+
+deny_test contains issue if {
 	issue := tflint.issue("example issue", terraform.module_range())
 }`,
 			},
@@ -38,7 +40,9 @@ deny_test[issue] {
 				"main.rego": `
 package tflint
 
-deny_test[issue] {
+import rego.v1
+
+deny_test contains issue if {
 	issue := tflint.issue(sprintf("data.foo is %s", [data.foo]), terraform.module_range())
 }`,
 				"data.yaml": `foo: bar`,
@@ -51,7 +55,9 @@ deny_test[issue] {
 				"main.rego": `
 package tflint
 
-deny_test[issue] {
+import rego.v1
+
+deny_test contains issue if {
 	resources := terraform.resources("aws_instance", {"instance_type": "string"}, {})
 	instance_type := resources[_].config.instance_type
 
@@ -74,7 +80,9 @@ resource "aws_instance" "main" {
 				"main.rego": `
 package tflint
 
-deny_test[issue] {
+import rego.v1
+
+deny_test contains issue if {
 	issue := tflint.issue(sprintf("OPA version: %s", [opa.runtime().version]), terraform.module_range())
 }`,
 			},
@@ -86,12 +94,14 @@ deny_test[issue] {
 				"main.rego": `
 package tflint
 
-deny_test[issue] {
+import rego.v1
+
+deny_test contains issue if {
 	unused := "foo"
 	issue := tflint.issue("example issue", terraform.module_range())
 }`,
 			},
-			err: "1 error occurred: main.rego:5: rego_compile_error: assigned var unused unused",
+			err: "1 error occurred: main.rego:7: rego_compile_error: assigned var unused unused",
 		},
 		{
 			name: "builtin errors",
@@ -99,13 +109,15 @@ deny_test[issue] {
 				"main.rego": `
 package tflint
 
-deny_test[issue] {
+import rego.v1
+
+deny_test contains issue if {
 	resources := terraform.resources("*", {}, {"unknown": "option"})
 	resource := resources[_]
 	issue := tflint.issue("example issue", resource.decl_range)
 }`,
 			},
-			err: "main.rego:5: eval_builtin_error: terraform.resources: unknown option: unknown",
+			err: "main.rego:7: eval_builtin_error: terraform.resources: unknown option: unknown",
 		},
 		{
 			name: "invalid issue",
@@ -113,7 +125,9 @@ deny_test[issue] {
 				"main.rego": `
 package tflint
 
-deny_test {
+import rego.v1
+
+deny_test if {
 	"foo" == "foo"
 }`,
 			},
@@ -175,7 +189,9 @@ func TestRunTest(t *testing.T) {
 				"main_test.rego": `
 package tflint
 
-test_deny {
+import rego.v1
+
+test_deny if {
 	"foo" == "bar"
 }`,
 			},
@@ -187,7 +203,9 @@ test_deny {
 				"main_test.rego": `
 package tflint
 
-test_deny {
+import rego.v1
+
+test_deny if {
 	"foo" == data.foo
 }`,
 				"data.yaml": `foo: bar`,
@@ -200,7 +218,9 @@ test_deny {
 				"main.rego": `
 package tflint
 
-deny_test[issue] {
+import rego.v1
+
+deny_test contains issue if {
 	resources := terraform.resources("aws_instance", {"instance_type": "string"}, {})
 	instance_type := resources[_].config.instance_type
 
@@ -211,12 +231,14 @@ deny_test[issue] {
 				"main_test.rego": `
 package tflint
 
+import rego.v1
+
 mock_resources(type, schema, options) := terraform.mock_resources(type, schema, options, {"main.tf": ` + "`" + `
 resource "aws_instance" "main" {
 	instance_type = "t1.micro"
 }` + "`" + `})
 
-test_deny {
+test_deny if {
 	count(deny_test) == 0 with terraform.resources as mock_resources
 }
 				`,
@@ -229,7 +251,9 @@ test_deny {
 				"main_test.rego": `
 package tflint
 
-test_deny {
+import rego.v1
+
+test_deny if {
 	"foo" == opa.runtime().version
 }`,
 			},

--- a/opa/rule_test.go
+++ b/opa/rule_test.go
@@ -69,7 +69,9 @@ func TestCheck_deny_instance_type(t *testing.T) {
 	policy := `
 package tflint
 
-deny_instance_type[issue] {
+import rego.v1
+
+deny_instance_type contains issue if {
 	resources := terraform.resources("aws_instance", {"instance_type": "string"}, {})
 	instance_type := resources[_].config.instance_type
 
@@ -136,7 +138,9 @@ func TestCheck_deny_non_snake_case(t *testing.T) {
 	policy := `
 package tflint
 
-deny_not_snake_case[issue] {
+import rego.v1
+
+deny_not_snake_case contains issue if {
 	resources := terraform.resources("*", {}, {})
 	not regex.match("^[a-z][a-z0-9]*(_[a-z0-9]+)*$", resources[i].name)
 
@@ -201,7 +205,9 @@ func TestCheck_warn_standard_volume(t *testing.T) {
 	policy := `
 package tflint
 
-warn_standard_volume[issue] {
+import rego.v1
+
+warn_standard_volume contains issue if {
 	resources := terraform.resources("aws_instance", {"ebs_block_device": {"volume_type": "string"}}, {})
 	volume_type := resources[_].config.ebs_block_device[_].config.volume_type
 	volume_type.value == "standard"
@@ -271,7 +277,9 @@ func TestCheck_deny_large_volume(t *testing.T) {
 	policy := `
 package tflint
 
-deny_large_volume[issue] {
+import rego.v1
+
+deny_large_volume contains issue if {
 	resources := terraform.resources("aws_instance", {"ebs_block_device": {"volume_size": "number"}}, {})
 	volume_size := resources[_].config.ebs_block_device[_].config.volume_size
 	volume_size.value > 30
@@ -367,17 +375,16 @@ func TestCheck_deny_untagged_instance(t *testing.T) {
 	policy := `
 package tflint
 
-contains(array, elem) {
-	array[_] = elem
+import rego.v1
+
+is_not_tagged(config) if {
+	not "Environment" in object.keys(config.tags.value)
 }
-is_not_tagged(config) {
-	not contains(object.keys(config.tags.value), "Environment")
-}
-is_not_tagged(config) {
-	not contains(object.keys(config), "tags")
+is_not_tagged(config) if {
+	not "tags" in object.keys(config)
 }
 
-deny_untagged_instance[issue] {
+deny_untagged_instance contains issue if {
 	resources := terraform.resources("aws_instance", {"tags": "map(string)"}, {})
 	resource := resources[_]
 
@@ -461,7 +468,9 @@ func TestCheck_deny_resource(t *testing.T) {
 	policy := `
 package tflint
 
-deny_resource[issue] {
+import rego.v1
+
+deny_resource contains issue if {
 	resources := terraform.resources("*", {}, {})
 	count(resources) > 0
 
@@ -526,7 +535,9 @@ func TestCheck_deny_no_resource(t *testing.T) {
 	policy := `
 package tflint
 
-deny_no_resource[issue] {
+import rego.v1
+
+deny_no_resource contains issue if {
 	resources := terraform.resources("*", {}, {})
 	count(resources) == 0
 
@@ -587,7 +598,9 @@ func TestCheck_deny_dynamic_block(t *testing.T) {
 	policy := `
 package tflint
 
-deny_dynamic_block[issue] {
+import rego.v1
+
+deny_dynamic_block contains issue if {
 	resources := terraform.resources("*", {"dynamic": {"__labels": ["name"]}}, {"expand_mode": "none"})
 	dynamic := resources[_].config.dynamic[_]
   

--- a/opa/test-fixtures/config/root-exists/.tflint.d/policies/main.rego
+++ b/opa/test-fixtures/config/root-exists/.tflint.d/policies/main.rego
@@ -1,26 +1,28 @@
 package tflint
 
-deny_not_snake_case[issue] {
-  resources := terraform.resources("*", {}, {})
-  not regex.match("^[a-z][a-z0-9]*(_[a-z0-9]+)*$", resources[i].name)
+import rego.v1
 
-  issue := tflint.issue(sprintf("%s is not snake case", [resources[i].name]), resources[i].decl_range)
+deny_not_snake_case contains issue if {
+	resources := terraform.resources("*", {}, {})
+	not regex.match("^[a-z][a-z0-9]*(_[a-z0-9]+)*$", resources[i].name)
+
+	issue := tflint.issue(sprintf("%s is not snake case", [resources[i].name]), resources[i].decl_range)
 }
 
-deny_not_t2_micro[issue] {
-  resources := terraform.resources("aws_instance", {"instance_type": "string"}, {})
-  instance_type := resources[_].config.instance_type
+deny_not_t2_micro contains issue if {
+	resources := terraform.resources("aws_instance", {"instance_type": "string"}, {})
+	instance_type := resources[_].config.instance_type
 
-  instance_type.unknown == true
+	instance_type.unknown == true
 
-  issue := tflint.issue("instance type is unknown", instance_type.range)
+	issue := tflint.issue("instance type is unknown", instance_type.range)
 }
 
-deny_not_t2_micro[issue] {
-  resources := terraform.resources("aws_instance", {"instance_type": "string"}, {})
-  instance_type := resources[_].config.instance_type
+deny_not_t2_micro contains issue if {
+	resources := terraform.resources("aws_instance", {"instance_type": "string"}, {})
+	instance_type := resources[_].config.instance_type
 
-  instance_type.value != "t2.micro"
+	instance_type.value != "t2.micro"
 
-  issue := tflint.issue("t2.micro is only allowed", instance_type.range)
+	issue := tflint.issue("t2.micro is only allowed", instance_type.range)
 }

--- a/opa/test-fixtures/config/root-exists/.tflint.d/policies/main_test.rego
+++ b/opa/test-fixtures/config/root-exists/.tflint.d/policies/main_test.rego
@@ -1,18 +1,18 @@
 package tflint
-import future.keywords
+
+import rego.v1
 
 mock_resources(type, schema, options) := terraform.mock_resources(type, schema, options, {"main.tf": `
 resource "aws_instance" "main-v2" {}
 `})
 
 test_deny_not_snake_case if {
-  issues := deny_not_snake_case
-    with terraform.resources as mock_resources
+	issues := deny_not_snake_case with terraform.resources as mock_resources
 
-  count(issues) == 1
-  issue := issues[_]
-  issue.msg == "main-v2 is not snake case"
-  issue.range.start.line == 2
+	count(issues) == 1
+	issue := issues[_]
+	issue.msg == "main-v2 is not snake case"
+	issue.range.start.line == 2
 }
 
 mock_resources_t1_micro(type, schema, options) := terraform.mock_resources(type, schema, options, {"main.tf": `
@@ -21,10 +21,10 @@ resource "aws_instance" "main" {
 }`})
 
 test_not_deny_t2_micro if {
-  issues := deny_not_t2_micro with terraform.resources as mock_resources_t1_micro
+	issues := deny_not_t2_micro with terraform.resources as mock_resources_t1_micro
 
-  count(issues) == 1
-  issue := issues[_]
-  issue.msg == "t2.micro is only allowed"
-  issue.range.start.line == 2
+	count(issues) == 1
+	issue := issues[_]
+	issue.msg == "t2.micro is only allowed"
+	issue.range.start.line == 2
 }

--- a/opa/test_rule_test.go
+++ b/opa/test_rule_test.go
@@ -48,7 +48,8 @@ func TestCheck_test_not_deny_t2_micro(t *testing.T) {
 	fs := memoryfs.New()
 	test := `
 package tflint
-import future.keywords
+
+import rego.v1
 
 mock_resources_t1_micro(type, schema, options) := terraform.mock_resources(type, schema, options, {"main.tf": ` + "`" + `
 resource "aws_instance" "main" {
@@ -74,7 +75,9 @@ test_not_deny_t2_micro if {
 			policy: `
 package tflint
 
-deny_not_t2_micro[issue] {
+import rego.v1
+
+deny_not_t2_micro contains issue if {
 	resources := terraform.resources("aws_db_instance", {"instance_type": "string"}, {})
 	instance_type := resources[_].config.instance_type
 
@@ -94,7 +97,9 @@ deny_not_t2_micro[issue] {
 			policy: `
 package tflint
 
-deny_not_t2_micro[issue] {
+import rego.v1
+
+deny_not_t2_micro contains issue if {
 	resources := terraform.resources("aws_instance", {"instance_type": "string"}, {})
 	instance_type := resources[_].config.instance_type
 
@@ -134,7 +139,8 @@ func TestCheck_test_deny_not_snake_case(t *testing.T) {
 	fs := memoryfs.New()
 	test := `
 package tflint
-import future.keywords
+
+import rego.v1
 
 mock_resources(type, schema, options) := terraform.mock_resources(type, schema, options, {"main.tf": ` + "`" + `
 resource "aws_instance" "main-v2" {}
@@ -161,7 +167,9 @@ test_deny_not_snake_case if {
 			policy: `
 package tflint
 
-deny_not_snake_case[issue] {
+import rego.v1
+
+deny_not_snake_case contains issue if {
 	resources := terraform.resources("*", {}, {})
 	regex.match("^[a-z][a-z0-9]*(_[a-z0-9]+)*$", resources[i].name)
 
@@ -179,7 +187,9 @@ deny_not_snake_case[issue] {
 			policy: `
 package tflint
 
-deny_not_snake_case[issue] {
+import rego.v1
+
+deny_not_snake_case contains issue if {
 	resources := terraform.resources("*", {}, {})
 	not regex.match("^[a-z][a-z0-9]*(_[a-z0-9]+)*$", resources[i].name)
 


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint-ruleset-opa/issues/81

Rewrite policies in the repository with `import rego.v1` for future OPA v1 release. Much of this rewriting was done with `opa fmt --rego-v1 -w`.

I intentionally added an integration test for the legacy syntax to detect when future OPA versions will no longer support the legacy syntax. I expect that this test will simply be removed when it is no longer supported.