### PR TITLE
release: Introduce Artifact Attestations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ on:
 permissions:
   contents: write
   id-token: write
+  attestations: write
 
 jobs:
   goreleaser:
@@ -33,3 +34,6 @@ jobs:
         args: release --rm-dist
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - uses: actions/attest-build-provenance@v1
+      with:
+        subject-path: 'dist/checksums.txt'


### PR DESCRIPTION
See also https://github.com/terraform-linters/tflint/pull/2038

This attestation is not yet used by `tflint --init`, but it will be used in future releases.