### PR TITLE
Add `terraform.ephemeral_resources` function

### DIFF
--- a/docs/functions.md
+++ b/docs/functions.md
@@ -732,6 +732,56 @@ terraform.removed_blocks({"from": "any"}, {})
 ]
 ```
 
+## `terraform.ephemeral_resources`
+
+```rego
+resources := terraform.ephemeral_resources(resource_type, schema, options)
+```
+
+Returns Terraform ephemeral resources.
+
+- `resource_type` (string): resource type to retrieve. "*" is a special character that returns all ephemeral resources.
+- `schema` (schema): schema for attributes referenced in rules.
+- `options` (object[string: string]): options to change the retrieve/evaluate behavior.
+
+Returns:
+
+- `resources` (array[object<type: string, name: string, config: body, decl_range: range>]): Terraform "ephemeral" blocks.
+
+The `schema` and `options` are equivalent to the arguments of the `terraform.resources` function.
+
+Examples:
+
+```hcl
+ephemeral "random_password" "db_password" {
+  length           = 16
+  override_special = "!#$%&*()-_=+[]{}<>:?"
+}
+```
+
+```rego
+terraform.ephemeral_resources("random_password", {"length": "number"}, {})
+```
+
+```json
+[
+  {
+    "type": "random_password",
+    "name": "db_password",
+    "config": {
+      "owners": {
+        "value": 16,
+        "unknown": false,
+        "sensitive": false,
+        "ephemeral": false,
+        "range": {...}
+      }
+    },
+    "decl_range": {...}
+  }
+]
+```
+
 ## `terraform.module_range`
 
 ```rego

--- a/integration/ephemerals/.tflint.hcl
+++ b/integration/ephemerals/.tflint.hcl
@@ -1,0 +1,9 @@
+plugin "terraform" {
+  enabled = false
+}
+
+plugin "opa" {
+  enabled = true
+
+  policy_dir = "policies"
+}

--- a/integration/ephemerals/main.tf
+++ b/integration/ephemerals/main.tf
@@ -1,0 +1,18 @@
+ephemeral "random_password" "db_password" {
+  length           = 16
+  override_special = "!#$%&*()-_=+[]{}<>:?"
+}
+
+resource "aws_secretsmanager_secret" "db_password" {
+  name = "db_password"
+}
+
+resource "aws_secretsmanager_secret_version" "db_password" {
+  secret_id                = aws_secretsmanager_secret.db_password.id
+  secret_string_wo         = ephemeral.random_password.db_password.result
+  secret_string_wo_version = 1
+}
+
+ephemeral "aws_secretsmanager_secret_version" "db_password" {
+  secret_id = aws_secretsmanager_secret_version.db_password.secret_id
+}

--- a/integration/ephemerals/policies/main.rego
+++ b/integration/ephemerals/policies/main.rego
@@ -1,0 +1,11 @@
+package tflint
+
+import rego.v1
+
+deny_weak_password contains issue if {
+	passwords := terraform.ephemeral_resources("random_password", {"length": "number"}, {})
+	length := passwords[_].config.length
+	length.value < 32
+
+	issue := tflint.issue("Password must be at least 32 characters long", length.range)
+}

--- a/integration/ephemerals/policies/main_test.rego
+++ b/integration/ephemerals/policies/main_test.rego
@@ -1,0 +1,22 @@
+package tflint
+import future.keywords
+
+mock_ephemeral_resources(type, schema, options) := terraform.mock_ephemeral_resources(type, schema, options, {"main.tf": `
+ephemeral "random_password" "db_password" {
+  length           = 16
+  override_special = "!#$%&*()-_=+[]{}<>:?"
+}`})
+
+test_deny_weak_password_passed if {
+  issues := deny_weak_password with terraform.ephemeral_resources as mock_ephemeral_resources
+
+  count(issues) == 1
+  issue := issues[_]
+  issue.msg == "Password must be at least 32 characters long"
+}
+
+test_deny_weak_password_failed if {
+  issues := deny_weak_password with terraform.ephemeral_resources as mock_ephemeral_resources
+
+  count(issues) == 0
+}

--- a/integration/ephemerals/result.json
+++ b/integration/ephemerals/result.json
@@ -1,0 +1,25 @@
+{
+  "issues": [
+    {
+      "rule": {
+        "name": "opa_deny_weak_password",
+        "severity": "error",
+        "link": "policies/main.rego:5"
+      },
+      "message": "Password must be at least 32 characters long",
+      "range": {
+        "filename": "main.tf",
+        "start": {
+          "line": 2,
+          "column": 22
+        },
+        "end": {
+          "line": 2,
+          "column": 24
+        }
+      },
+      "callers": []
+    }
+  ],
+  "errors": []
+}

--- a/integration/ephemerals/result_test.json
+++ b/integration/ephemerals/result_test.json
@@ -1,0 +1,25 @@
+{
+  "issues": [
+    {
+      "rule": {
+        "name": "opa_test_deny_weak_password_failed",
+        "severity": "error",
+        "link": "policies/main_test.rego:18"
+      },
+      "message": "test failed",
+      "range": {
+        "filename": "",
+        "start": {
+          "line": 0,
+          "column": 0
+        },
+        "end": {
+          "line": 0,
+          "column": 0
+        }
+      },
+      "callers": []
+    }
+  ],
+  "errors": []
+}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -247,6 +247,17 @@ func TestIntegration(t *testing.T) {
 			dir:     "legacy_rego_syntax",
 			test:    true,
 		},
+		{
+			name:    "ephemerals",
+			command: exec.Command("tflint", "--format", "json", "--force"),
+			dir:     "ephemerals",
+		},
+		{
+			name:    "ephemerals (test)",
+			command: exec.Command("tflint", "--format", "json", "--force"),
+			dir:     "ephemerals",
+			test:    true,
+		},
 	}
 
 	dir, _ := os.Getwd()


### PR DESCRIPTION
See https://developer.hashicorp.com/terraform/language/resources/ephemeral

This change adds a new `terraform.ephemeral_resources` function. This correspond to the ephemeral resources introduced in Terraform v1.10. The function interface and return values are pretty much the same as other functions, so there's no new functionality.