### PR TITLE
Add "expr" type as a schema type

### DIFF
--- a/docs/functions.md
+++ b/docs/functions.md
@@ -795,6 +795,170 @@ Returns:
 
 - `range` (range): a range for [DIR]/main.tf:1:1
 
+## `hcl.expr_list`
+
+```rego
+exprs := hcl.expr_list(expr)
+```
+
+Extract a list of expressions from the given static list expression.
+This is equivalent to [`hcl.ExprList`](https://github.com/hashicorp/hcl/blob/v2.24.0/expr_list.go#L17).
+
+- `expr` (raw_expr): static list expression which is retrieved as an [`expr` type](./schema.md#expr-type).
+
+Returns:
+
+- `exprs` (array[raw_expr]): expressions as elements of the list.
+
+Types:
+
+|Name|Type|
+|---|---|
+|`raw_expr`|`object<value: string, range: range>`|
+
+Examples:
+
+```hcl
+resource "aws_instance" "main" {
+  lifecycle {
+    ignore_changes = [key_name, tags]
+  }
+}
+```
+
+```rego
+instances := terraform.resources("*", {"lifecycle": {"ignore_changes": "expr"}}, {"expand_mode": "none"})
+hcl.expr_list(instances[i].config.lifecycle[j].config.ignore_changes)
+```
+
+```json
+[
+  {
+    "value": "key_name",
+    "range": {...}
+  },
+  {
+    "value": "tags",
+    "range": {...}
+  }
+]
+```
+
+## `hcl.expr_map`
+
+```rego
+pairs := hcl.expr_map(expr)
+```
+
+Extract a list of key value pairs from the given static map expression.
+This is equivalent to [hcl.ExprMap](https://github.com/hashicorp/hcl/blob/v2.24.0/expr_map.go#L17).
+
+- `expr` (raw_expr): static map expression which is retrieved as an [`expr` type](./schema.md#expr-type).
+
+Returns:
+
+- `pairs` (array[key_value]): key value pairs of the map as expressions.
+
+Types:
+
+|Name|Type|
+|---|---|
+|`key_value`|`object<key: raw_expr, value: raw_expr>`|
+
+Examples:
+
+```hcl
+module "tunnel" {
+  source    = "./tunnel"
+  providers = {
+    aws.src = aws.usw1
+    aws.dst = aws.usw2
+  }
+}
+```
+
+```rego
+calls := terraform.module_calls({"providers": "expr"})
+hcl.expr_map(calls[i].config.providers)
+```
+
+```json
+[
+  {
+    "key": {
+      "value": "aws.src",
+      "range": {...}
+    },
+    "value": {
+      "value": "aws.usw1",
+      "range": {...}
+    }
+  },
+  {
+    "key": {
+      "value": "aws.dst",
+      "range": {...}
+    },
+    "value": {
+      "value": "aws.usw2",
+      "range": {...}
+    }
+  }
+]
+```
+
+## `hcl.expr_call`
+
+```rego
+call := hcl.expr_call(expr)
+```
+
+Extract the function name and arguments from the given function call expression.
+This is equivalent to [hcl.ExprCall](https://github.com/hashicorp/hcl/blob/v2.24.0/expr_call.go#L17).
+
+- `expr` (raw_expr): function call expression which is retrieved as an [`expr` type](./schema.md#expr-type).
+
+Returns:
+
+- `call` (call): function call object.
+
+Types:
+
+|Name|Type|
+|---|---|
+|`call`|`object<name: string, name_range: range, arguments: array[raw_expr], args_range: range>`|
+
+Examples:
+
+```hcl
+resource "aws_instance" "main" {
+  ami = provider::custom::get_ami_id("web", "v0.9")
+}
+```
+
+```rego
+instances := terraform.resources("aws_instance", {"ami": "expr"})
+hcl.expr_call(instances[i].config.ami)
+```
+
+```json
+{
+  "name": "provider::custom::get_ami_id",
+  "name_range": {...},
+  "arguments": [
+    {
+      "value": "\"web\"",
+      "range": {...}
+    },
+    {
+      "value": "\"v0.9\"",
+      "range": {...}
+    }
+  ],
+  "args_range": {...}
+}
+```
+
 ## `tflint.issue`
 
 ```rego

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -10,25 +10,33 @@ For example, a schema required to decode the top-level `instance_type` is:
 {"instance_type": "string"}
 ```
 
-The object's key is the attribute name and the value represents the type. The type syntax is the same as [Terraform's type constraints](https://developer.hashicorp.com/terraform/language/expressions/type-constraints).
+The object's key is the attribute name and the value represents the type. The type syntax is essentially the same as [Terraform's type constraints](https://developer.hashicorp.com/terraform/language/expressions/type-constraints).
+
+## `any` Type
 
 TFLint implicitly converts values according to their type, which is useful when working with numbers.
 
+```rego
+{"size": "number"}
+```
+
 ```hcl
-resource "aws_instance" "number" {
-  ebs_block_device {
-    volume_size = 50
-  }
+resource "aws_ebs_volume" "number" {
+  size = 50
 }
 
-resource "aws_instance" "string" {
-  ebs_block_device {
-    volume_size = "50" # => convert to number in JSON
-  }
+resource "aws_ebs_volume" "string" {
+  size = "50" # => convert to number in JSON
 }
 ```
 
-If you don't know the attribute type, you can use `any`. In this case no conversion is done, but the raw value from the config file is available.
+If you don't know the attribute type, you can use `any`. In this case no conversion is done, but the raw value from the config file is available. In the above example, the JSON will contain 50 and "50".
+
+```rego
+{"size": "any"}
+```
+
+## Nested Blocks
 
 A schema for decoding nested blocks is:
 
@@ -53,3 +61,46 @@ resource "aws_instance" "main" {
 ```
 
 The `__labels` is a special key that sets labels. The value defines the label name in an array, not the type. Label names are basically meaningless.
+
+## `expr` Type
+
+The `expr` type can be used as a special type. Attributes specified as `expr` type are not evaluated immediately, but the structure of the expression is included in the value.
+
+```hcl
+variable "instance_type" {
+  default = "t2.micro"
+}
+
+resource "aws_instance" "main" {
+  instance_type = var.instance_type
+}
+```
+
+```rego
+{"instance_type": "string"}
+```
+
+```json
+{
+  "value": "t2.micro",
+  "unknown": false,
+  "sensitive": false,
+  "ephemeral": false,
+  "range": {...}
+}
+```
+
+```rego
+{"instance_type": "expr"}
+```
+
+```json
+{
+  "value": "var.instance_type",
+  "range": {...}
+}
+```
+
+This is useful for writing policies over expression structures. For example, the `expr` type is the only way to handle meta-arguments such as `ignore_changes` that cannot be evaluated in the normal way.
+
+The value obtained with the `expr` type is called `raw_expr` type and can be passed to HCL static analysis functions such as [`hcl.expr_list`](./functions.md#hclexpr_list), [`hcl.expr_map`](./functions.md#hclexpr_map), and [`hcl.expr_call`](./functions.md#hclexpr_call).

--- a/examples/enforce_tags_ignore/.tflint.d/policies/tags.rego
+++ b/examples/enforce_tags_ignore/.tflint.d/policies/tags.rego
@@ -1,0 +1,41 @@
+package tflint
+
+import rego.v1
+
+aws_instances := terraform.resources("aws_instance", {"lifecycle": {"ignore_changes": "expr"}}, {"expand_mode": "none"})
+
+# ignore_changes = [tags]
+has_tags_ignore(instance) if {
+	ignore_changes := instance.config.lifecycle[_].config.ignore_changes
+
+    startswith(ignore_changes.value, "[")
+	some i
+	hcl.expr_list(ignore_changes)[i].value == "tags"
+}
+
+# ignore_changes = ["tags"]
+has_tags_ignore(instance) if {
+	ignore_changes := instance.config.lifecycle[_].config.ignore_changes
+
+    startswith(ignore_changes.value, "[")
+	some i
+	hcl.expr_list(ignore_changes)[i].value == `"tags"`
+}
+
+# ignore_changes = all
+has_tags_ignore(instance) if {
+	ignore_changes := instance.config.lifecycle[_].config.ignore_changes
+    ignore_changes.value == "all"
+}
+
+# ignore_changes = "all"
+has_tags_ignore(instance) if {
+	ignore_changes := instance.config.lifecycle[_].config.ignore_changes
+    ignore_changes.value == `"all"`
+}
+
+deny_instance_without_tags_ignore contains issue if {
+	not has_tags_ignore(aws_instances[i])
+
+	issue := tflint.issue(`instance must have "ignore_changes = [tags]"`, aws_instances[i].decl_range)
+}

--- a/examples/enforce_tags_ignore/.tflint.d/policies/tags_test.rego
+++ b/examples/enforce_tags_ignore/.tflint.d/policies/tags_test.rego
@@ -1,0 +1,98 @@
+package tflint
+
+import rego.v1
+
+failed_resources(type, schema, options) := terraform.mock_resources(type, schema, options, {"main.tf": `
+resource "aws_instance" "invalid" {
+  lifecycle {
+    ignore_changes = [key_name, ami]
+  }
+}`})
+
+test_deny_instance_without_tags_ignore_failed if {
+	issues := deny_instance_without_tags_ignore with terraform.resources as failed_resources
+
+	count(issues) == 1
+	issue := issues[_]
+	issue.msg == `instance must have "ignore_changes = [tags]"`
+}
+
+passed_resources(type, schema, options) := terraform.mock_resources(type, schema, options, {"main.tf": `
+resource "aws_instance" "valid" {
+  lifecycle {
+    ignore_changes = [key_name, tags]
+  }
+}`})
+
+test_deny_instance_without_tags_ignore_passed if {
+	issues := deny_instance_without_tags_ignore with terraform.resources as passed_resources
+
+	count(issues) == 0
+}
+
+without_ignore_changes_resources(type, schema, options) := terraform.mock_resources(type, schema, options, {"main.tf": `
+resource "aws_instance" "without_ignore_changes" {
+  lifecycle {
+    create_before_destroy = true
+  }
+}`})
+
+test_deny_instance_without_tags_ignore_without_ignore_changes if {
+	issues := deny_instance_without_tags_ignore with terraform.resources as without_ignore_changes_resources
+
+	count(issues) == 1
+	issue := issues[_]
+	issue.msg == `instance must have "ignore_changes = [tags]"`
+}
+
+without_lifecycle_resources(type, schema, options) := terraform.mock_resources(type, schema, options, {"main.tf": `
+resource "aws_instance" "without_lifecycle" {
+  instance_type = "t2.micro"
+}`})
+
+test_deny_instance_without_tags_ignore_without_lifecycle if {
+	issues := deny_instance_without_tags_ignore with terraform.resources as without_lifecycle_resources
+
+	count(issues) == 1
+	issue := issues[_]
+	issue.msg == `instance must have "ignore_changes = [tags]"`
+}
+
+deprecated_ignore_resources(type, schema, options) := terraform.mock_resources(type, schema, options, {"main.tf": `
+resource "aws_instance" "valid" {
+  lifecycle {
+    ignore_changes = ["key_name", "tags"]
+  }
+}`})
+
+test_deny_instance_without_tags_ignore_deprecated_ignore if {
+	issues := deny_instance_without_tags_ignore with terraform.resources as deprecated_ignore_resources
+
+	count(issues) == 0
+}
+
+ignore_all_resources(type, schema, options) := terraform.mock_resources(type, schema, options, {"main.tf": `
+resource "aws_instance" "valid" {
+  lifecycle {
+    ignore_changes = all
+  }
+}`})
+
+test_deny_instance_without_tags_ignore_deprecated_ignore if {
+	issues := deny_instance_without_tags_ignore with terraform.resources as ignore_all_resources
+
+	count(issues) == 0
+}
+
+deprecated_ignore_all_resources(type, schema, options) := terraform.mock_resources(type, schema, options, {"main.tf": `
+resource "aws_instance" "valid" {
+  lifecycle {
+    ignore_changes = "all"
+  }
+}`})
+
+test_deny_instance_without_tags_ignore_deprecated_ignore if {
+	issues := deny_instance_without_tags_ignore with terraform.resources as deprecated_ignore_all_resources
+
+	count(issues) == 0
+}

--- a/examples/enforce_tags_ignore/.tflint.hcl
+++ b/examples/enforce_tags_ignore/.tflint.hcl
@@ -1,0 +1,7 @@
+plugin "opa" {
+  enabled = true
+}
+
+plugin "terraform" {
+  enabled = false
+}

--- a/examples/enforce_tags_ignore/README.md
+++ b/examples/enforce_tags_ignore/README.md
@@ -1,0 +1,39 @@
+# Enforce tags ignore
+
+This is an example of a policy that disallows declaring AWS instances without `ignore_changes = [tags]`.
+
+## Requirements
+
+- Disallow AWS instances that do not ignore `tags`.
+- Allow `ignore_changes = all`.
+- Allow deprecated `ignore_changes` syntax (e.g. `"tags"`, `"all"`).
+- Always warn even if the instance is not created.
+
+## Results
+
+```console
+$ tflint
+3 issue(s) found:
+
+Error: instance must have "ignore_changes = [tags]" (opa_deny_instance_without_tags_ignore)
+
+  on main.tf line 7:
+   7: resource "aws_instance" "invalid" {
+
+Reference: .tflint.d/policies/tags.rego:37
+
+Error: instance must have "ignore_changes = [tags]" (opa_deny_instance_without_tags_ignore)
+
+  on main.tf line 13:
+  13: resource "aws_instance" "without_ignore_changes" {
+
+Reference: .tflint.d/policies/tags.rego:37
+
+Error: instance must have "ignore_changes = [tags]" (opa_deny_instance_without_tags_ignore)
+
+  on main.tf line 19:
+  19: resource "aws_instance" "without_lifecycle" {
+
+Reference: .tflint.d/policies/tags.rego:37
+
+```

--- a/examples/enforce_tags_ignore/main.tf
+++ b/examples/enforce_tags_ignore/main.tf
@@ -1,0 +1,39 @@
+resource "aws_instance" "valid" {
+  lifecycle {
+    ignore_changes = [key_name, tags]
+  }
+}
+
+resource "aws_instance" "invalid" {
+  lifecycle {
+    ignore_changes = [key_name, ami]
+  }
+}
+
+resource "aws_instance" "without_ignore_changes" {
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_instance" "without_lifecycle" {
+  instance_type = "t2.micro"
+}
+
+resource "aws_instance" "all" {
+  lifecycle {
+    ignore_changes = all
+  }
+}
+
+resource "aws_instance" "deprecated_ignore" {
+  lifecycle {
+    ignore_changes = ["tags"]
+  }
+}
+
+resource "aws_instance" "deprecated_all" {
+  lifecycle {
+    ignore_changes = "all"
+  }
+}

--- a/integration/expr_without_eval/.tflint.hcl
+++ b/integration/expr_without_eval/.tflint.hcl
@@ -1,0 +1,9 @@
+plugin "terraform" {
+  enabled = false
+}
+
+plugin "opa" {
+  enabled = true
+
+  policy_dir = "policies"
+}

--- a/integration/expr_without_eval/main.tf
+++ b/integration/expr_without_eval/main.tf
@@ -1,0 +1,27 @@
+resource "aws_instance" "valid" {
+  ami = get_ami_id("service1", "v1")
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}
+
+resource "aws_instance" "invalid" {
+  ami = get_ami_id("service1", "v0.9")
+
+  lifecycle {
+    ignore_changes = [ami]
+  }
+}
+
+module "valid" {
+  providers = {
+    aws = aws.usw1
+  }
+}
+
+module "invalid" {
+  providers = {
+    aws = aws.usw2
+  }
+}

--- a/integration/expr_without_eval/policies/main.rego
+++ b/integration/expr_without_eval/policies/main.rego
@@ -1,0 +1,58 @@
+package tflint
+
+import rego.v1
+
+deny_require_lifecycle_ignore_tags contains issue if {
+  res := terraform.resources("*",{"lifecycle": {"ignore_changes": "expr"}},{"expand_mode": "none"})[_]
+  not has_tags_ignore(res)
+
+  issue := tflint.issue(
+    sprintf("Resource %s.%s must have lifecycle.ignore_changes include \"tags\"", [res.type, res.name]),
+    res.decl_range
+  )
+}
+
+# helper succeeds only if there's a lifecycle.ignore_changes list and one of its elements == "tags"
+has_tags_ignore(res) if {
+  lifeblock := res.config.lifecycle[_]
+
+  ic := lifeblock.config.ignore_changes
+
+  some i
+  hcl.expr_list(ic)[i].value == "tags"
+}
+
+deny_deprecated_regions contains issue if {
+  call := terraform.module_calls({"providers": "expr"}, {})[_]
+  has_deprecated_region(call)
+
+  issue := tflint.issue(
+    "deprecated region reference found",
+    call.config.providers.range,
+  )
+}
+
+has_deprecated_region(call) if {
+  providers := call.config.providers
+
+  some i
+  hcl.expr_map(providers)[i].value.value == "aws.usw2"
+}
+
+deny_deprecated_ami_version contains issue if {
+  instance := terraform.resources("aws_instance", {"ami": "expr"}, {})[_]
+  is_function_call_with_deprecated_version(instance)
+
+  issue := tflint.issue(
+    "get_ami_id function should be called with v1",
+    instance.decl_range
+  )
+}
+
+is_function_call_with_deprecated_version(instance) if {
+  ami := instance.config.ami
+
+  call := hcl.expr_call(ami)
+  call.name == "get_ami_id"
+  call.arguments[1].value != `"v1"`
+}

--- a/integration/expr_without_eval/policies/main_test.rego
+++ b/integration/expr_without_eval/policies/main_test.rego
@@ -1,0 +1,122 @@
+package tflint
+
+import rego.v1
+
+invalid_resources(type, schema, options) := terraform.mock_resources(type, schema, options, {
+  "main.tf": `
+resource "aws_instance" "invalid" {
+  ami = get_ami_id("service1", "v0.9")
+
+  lifecycle {
+    ignore_changes = [ami]
+  }
+}
+`,
+})
+
+valid_resources(type, schema, options) := terraform.mock_resources(type, schema, options, {
+  "main.tf": `
+resource "aws_instance" "valid" {
+  ami = get_ami_id("service1", "v1")
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}
+`,
+})
+
+test_wrong_ignore_passed if {
+  issues := deny_require_lifecycle_ignore_tags with terraform.resources as invalid_resources
+
+  count(issues) == 1
+  issues[_].msg == "Resource aws_instance.invalid must have lifecycle.ignore_changes include \"tags\""
+}
+
+test_wrong_ignore_failed if {
+  issues := deny_require_lifecycle_ignore_tags with terraform.resources as invalid_resources
+
+  count(issues) == 0
+}
+
+test_correct_ignore_passed if {
+  issues := deny_require_lifecycle_ignore_tags with terraform.resources as valid_resources
+
+  count(issues) == 0
+}
+
+test_correct_ignore_failed if {
+  issues := deny_require_lifecycle_ignore_tags with terraform.resources as valid_resources
+
+  count(issues) == 1
+}
+
+test_wrong_ami_passed if {
+  issues := deny_deprecated_ami_version with terraform.resources as invalid_resources
+
+  count(issues) == 1
+  issues[_].msg == "get_ami_id function should be called with v1"
+}
+
+test_wrong_ami_failed if {
+  issues := deny_deprecated_ami_version with terraform.resources as invalid_resources
+
+  count(issues) == 0
+}
+
+test_correct_ami_passed if {
+  issues := deny_deprecated_ami_version with terraform.resources as valid_resources
+
+  count(issues) == 0
+}
+
+test_correct_ami_failed if {
+  issues := deny_deprecated_ami_version with terraform.resources as valid_resources
+
+  count(issues) == 1
+}
+
+invalid_calls(schema, options) := terraform.mock_module_calls(schema, options, {
+  "main.tf": `
+module "invalid" {
+  providers = {
+    aws = aws.usw2
+  }
+}
+`,
+})
+
+valid_calls(schema, options) := terraform.mock_module_calls(schema, options, {
+  "main.tf": `
+module "valid" {
+  providers = {
+    aws = aws.usw1
+  }
+}
+`,
+})
+
+test_wrong_region_passed if {
+  issues := deny_deprecated_regions with terraform.module_calls as invalid_calls
+
+  count(issues) == 1
+  issues[_].msg == "deprecated region reference found"
+}
+
+test_wrong_region_failed if {
+  issues := deny_deprecated_regions with terraform.module_calls as invalid_calls
+
+  count(issues) == 0
+}
+
+test_correct_region_passed if {
+  issues := deny_deprecated_regions with terraform.module_calls as valid_calls
+
+  count(issues) == 0
+}
+
+test_correct_region_failed if {
+  issues := deny_deprecated_regions with terraform.module_calls as valid_calls
+
+  count(issues) == 1
+}

--- a/integration/expr_without_eval/result.json
+++ b/integration/expr_without_eval/result.json
@@ -1,0 +1,65 @@
+{
+  "issues": [
+    {
+      "rule": {
+        "name": "opa_deny_require_lifecycle_ignore_tags",
+        "severity": "error",
+        "link": "policies/main.rego:5"
+      },
+      "message": "Resource aws_instance.invalid must have lifecycle.ignore_changes include \"tags\"",
+      "range": {
+        "filename": "main.tf",
+        "start": {
+          "line": 9,
+          "column": 1
+        },
+        "end": {
+          "line": 9,
+          "column": 34
+        }
+      },
+      "callers": []
+    },
+    {
+      "rule": {
+        "name": "opa_deny_deprecated_ami_version",
+        "severity": "error",
+        "link": "policies/main.rego:42"
+      },
+      "message": "get_ami_id function should be called with v1",
+      "range": {
+        "filename": "main.tf",
+        "start": {
+          "line": 9,
+          "column": 1
+        },
+        "end": {
+          "line": 9,
+          "column": 34
+        }
+      },
+      "callers": []
+    },
+    {
+      "rule": {
+        "name": "opa_deny_deprecated_regions",
+        "severity": "error",
+        "link": "policies/main.rego:25"
+      },
+      "message": "deprecated region reference found",
+      "range": {
+        "filename": "main.tf",
+        "start": {
+          "line": 24,
+          "column": 15
+        },
+        "end": {
+          "line": 26,
+          "column": 4
+        }
+      },
+      "callers": []
+    }
+  ],
+  "errors": []
+}

--- a/integration/expr_without_eval/result_test.json
+++ b/integration/expr_without_eval/result_test.json
@@ -1,0 +1,125 @@
+{
+  "issues": [
+    {
+      "rule": {
+        "name": "opa_test_wrong_ignore_failed",
+        "severity": "error",
+        "link": "policies/main_test.rego:36"
+      },
+      "message": "test failed",
+      "range": {
+        "filename": "",
+        "start": {
+          "line": 0,
+          "column": 0
+        },
+        "end": {
+          "line": 0,
+          "column": 0
+        }
+      },
+      "callers": []
+    },
+    {
+      "rule": {
+        "name": "opa_test_correct_ignore_failed",
+        "severity": "error",
+        "link": "policies/main_test.rego:48"
+      },
+      "message": "test failed",
+      "range": {
+        "filename": "",
+        "start": {
+          "line": 0,
+          "column": 0
+        },
+        "end": {
+          "line": 0,
+          "column": 0
+        }
+      },
+      "callers": []
+    },
+    {
+      "rule": {
+        "name": "opa_test_wrong_ami_failed",
+        "severity": "error",
+        "link": "policies/main_test.rego:61"
+      },
+      "message": "test failed",
+      "range": {
+        "filename": "",
+        "start": {
+          "line": 0,
+          "column": 0
+        },
+        "end": {
+          "line": 0,
+          "column": 0
+        }
+      },
+      "callers": []
+    },
+    {
+      "rule": {
+        "name": "opa_test_correct_ami_failed",
+        "severity": "error",
+        "link": "policies/main_test.rego:73"
+      },
+      "message": "test failed",
+      "range": {
+        "filename": "",
+        "start": {
+          "line": 0,
+          "column": 0
+        },
+        "end": {
+          "line": 0,
+          "column": 0
+        }
+      },
+      "callers": []
+    },
+    {
+      "rule": {
+        "name": "opa_test_wrong_region_failed",
+        "severity": "error",
+        "link": "policies/main_test.rego:106"
+      },
+      "message": "test failed",
+      "range": {
+        "filename": "",
+        "start": {
+          "line": 0,
+          "column": 0
+        },
+        "end": {
+          "line": 0,
+          "column": 0
+        }
+      },
+      "callers": []
+    },
+    {
+      "rule": {
+        "name": "opa_test_correct_region_failed",
+        "severity": "error",
+        "link": "policies/main_test.rego:118"
+      },
+      "message": "test failed",
+      "range": {
+        "filename": "",
+        "start": {
+          "line": 0,
+          "column": 0
+        },
+        "end": {
+          "line": 0,
+          "column": 0
+        }
+      },
+      "callers": []
+    }
+  ],
+  "errors": []
+}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -247,6 +247,17 @@ func TestIntegration(t *testing.T) {
 			dir:     "ephemerals",
 			test:    true,
 		},
+		{
+			name:    "expr without eval",
+			command: exec.Command("tflint", "--format", "json", "--force"),
+			dir:     "expr_without_eval",
+		},
+		{
+			name:    "expr without eval (test)",
+			command: exec.Command("tflint", "--format", "json", "--force"),
+			dir:     "expr_without_eval",
+			test:    true,
+		},
 	}
 
 	dir, _ := os.Getwd()

--- a/opa/functions.go
+++ b/opa/functions.go
@@ -32,6 +32,9 @@ func Functions(runner tflint.Runner) []func(*rego.Rego) {
 		removedBlocksFunc(runner).asOption(),
 		ephemeralResourcesFunc(runner).asOption(),
 		moduleRangeFunc(runner).asOption(),
+		exprListFunc().asOption(),
+		exprMapFunc().asOption(),
+		exprCallFunc().asOption(),
 		issueFunc().asOption(),
 	}
 }
@@ -53,6 +56,9 @@ func TesterFunctions(runner tflint.Runner) []*tester.Builtin {
 		removedBlocksFunc(runner).asTester(),
 		ephemeralResourcesFunc(runner).asTester(),
 		moduleRangeFunc(runner).asTester(),
+		exprListFunc().asTester(),
+		exprMapFunc().asTester(),
+		exprCallFunc().asTester(),
 		issueFunc().asTester(),
 	}
 }
@@ -642,6 +648,168 @@ func moduleRangeFunc(runner tflint.Runner) *functionDyn {
 	}
 }
 
+// hcl.expr_list: exprs := hcl.expr_list(expr)
+//
+// Extract a list of expressions from the given static list expression.
+// This is equivalent to hcl.ExprList in hashicorp/hcl.
+//
+//	expr (raw_expr) static list expression which is retrieved as an expr type.
+//
+// Returns:
+//
+//	exprs (array[raw_expr]) expressions as elements of the list.
+func exprListFunc() *function1 {
+	return &function1{
+		function: function{
+			Decl: &rego.Function{
+				Name:    "hcl.expr_list",
+				Decl:    types.NewFunction(types.Args(rawExprTy), types.NewArray(nil, rawExprTy)),
+				Memoize: true,
+			},
+		},
+		Func: func(_ rego.BuiltinContext, exprArg *ast.Term) (*ast.Term, error) {
+			expr, src, err := astAsExpr(exprArg)
+			if err != nil {
+				return nil, err
+			}
+			src = prependZeroPadding(src, expr.Range().Start)
+
+			exprs, diags := hcl.ExprList(expr)
+			if diags.HasErrors() {
+				return nil, diags
+			}
+			ret := make([]map[string]any, len(exprs))
+			for i, e := range exprs {
+				ret[i] = rawExprToJSON(e, []byte(src))
+			}
+
+			v, err := ast.InterfaceToValue(ret)
+			if err != nil {
+				return nil, err
+			}
+			return ast.NewTerm(v), nil
+		},
+	}
+}
+
+// key_value (object<key: raw_expr, value: raw_expr>) representation of a key value pair
+var keyValueTy = types.NewObject(
+	[]*types.StaticProperty{
+		types.NewStaticProperty("key", rawExprTy),
+		types.NewStaticProperty("value", rawExprTy),
+	},
+	nil,
+)
+
+// hcl.expr_map: pairs := hcl.expr_map(expr)
+//
+// Extract a list of key value pairs from the given static map expression.
+// This is equivalent to hcl.ExprMap in hashicorp/hcl.
+//
+//	expr (raw_expr) static map expression which is retrieved as an expr type.
+//
+// Returns:
+//
+//	pairs (array[key_value]) key value pairs of the map as expressions.
+func exprMapFunc() *function1 {
+	return &function1{
+		function: function{
+			Decl: &rego.Function{
+				Name:    "hcl.expr_map",
+				Decl:    types.NewFunction(types.Args(rawExprTy), types.NewArray(nil, keyValueTy)),
+				Memoize: true,
+			},
+		},
+		Func: func(_ rego.BuiltinContext, exprArg *ast.Term) (*ast.Term, error) {
+			expr, src, err := astAsExpr(exprArg)
+			if err != nil {
+				return nil, err
+			}
+			src = prependZeroPadding(src, expr.Range().Start)
+
+			pairs, diags := hcl.ExprMap(expr)
+			if diags.HasErrors() {
+				return nil, diags
+			}
+			ret := make([]map[string]map[string]any, len(pairs))
+			for i, pair := range pairs {
+				ret[i] = map[string]map[string]any{
+					"key":   rawExprToJSON(pair.Key, []byte(src)),
+					"value": rawExprToJSON(pair.Value, []byte(src)),
+				}
+			}
+
+			v, err := ast.InterfaceToValue(ret)
+			if err != nil {
+				return nil, err
+			}
+			return ast.NewTerm(v), nil
+		},
+	}
+}
+
+// call (object<name: string, name_range: range, arguments: array[raw_expr], args_range: range>) representation of a static function call
+var callTy = types.NewObject(
+	[]*types.StaticProperty{
+		types.NewStaticProperty("name", types.S),
+		types.NewStaticProperty("name_range", rangeTy),
+		types.NewStaticProperty("arguments", types.NewArray(nil, rawExprTy)),
+		types.NewStaticProperty("args_range", rangeTy),
+	},
+	nil,
+)
+
+// hcl.expr_call: call := hcl.expr_call(expr)
+//
+// Extract the function name and arguments from the given function call expression.
+// This is equivalent to hcl.ExprCall in hashicorp/hcl.
+//
+//	expr (raw_expr) function call expression which is retrieved as an expr type.
+//
+// Returns:
+//
+//	call (call) function call object
+func exprCallFunc() *function1 {
+	return &function1{
+		function: function{
+			Decl: &rego.Function{
+				Name:    "hcl.expr_call",
+				Decl:    types.NewFunction(types.Args(rawExprTy), callTy),
+				Memoize: true,
+			},
+		},
+		Func: func(_ rego.BuiltinContext, exprArg *ast.Term) (*ast.Term, error) {
+			expr, src, err := astAsExpr(exprArg)
+			if err != nil {
+				return nil, err
+			}
+			src = prependZeroPadding(src, expr.Range().Start)
+
+			call, diags := hcl.ExprCall(expr)
+			if diags.HasErrors() {
+				return nil, diags
+			}
+
+			arguments := make([]map[string]any, len(call.Arguments))
+			for i, arg := range call.Arguments {
+				arguments[i] = rawExprToJSON(arg, []byte(src))
+			}
+			ret := map[string]any{
+				"name":       call.Name,
+				"name_range": rangeToJSON(call.NameRange),
+				"arguments":  arguments,
+				"args_range": rangeToJSON(call.ArgsRange),
+			}
+
+			v, err := ast.InterfaceToValue(ret)
+			if err != nil {
+				return nil, err
+			}
+			return ast.NewTerm(v), nil
+		},
+	}
+}
+
 // tflint.issue: issue := tflint.issue(msg, range)
 //
 // Returns issue object
@@ -808,6 +976,44 @@ func blockFunc(schemaArg *ast.Term, optionArg *ast.Term, blockType string, runne
 	}
 
 	return ast.NewTerm(v), nil
+}
+
+func astAsExpr(v *ast.Term) (hcl.Expression, string, error) {
+	var exprMap map[string]any
+	if err := ast.As(v.Value, &exprMap); err != nil {
+		return nil, "", err
+	}
+
+	value, ok := exprMap["value"]
+	if !ok {
+		return nil, "", fmt.Errorf("expr must have a 'value' key")
+	}
+	valueStr, ok := value.(string)
+	if !ok {
+		return nil, "", fmt.Errorf("expr value must be a string")
+	}
+
+	rngArg, ok := exprMap["range"]
+	if !ok {
+		return nil, "", fmt.Errorf("expr must have a 'range' key")
+	}
+	rng, err := jsonToRange(rngArg, "expr.range")
+	if err != nil {
+		return nil, "", err
+	}
+
+	expr, diags := hclext.ParseExpression([]byte(valueStr), rng.Filename, rng.Start)
+	if diags.HasErrors() {
+		return nil, "", diags
+	}
+	return expr, valueStr, nil
+}
+
+// prependZeroPadding to the source code so that the position of the expression
+// is correct. This is necessary because the position is relative to the start of
+// the source code.
+func prependZeroPadding(src string, pos hcl.Pos) string {
+	return strings.Repeat("0", pos.Byte) + src
 }
 
 type function struct {

--- a/opa/functions_test.go
+++ b/opa/functions_test.go
@@ -5,8 +5,11 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/open-policy-agent/opa/v1/ast"
 	"github.com/open-policy-agent/opa/v1/rego"
+	"github.com/zclconf/go-cty/cty"
 )
 
 func TestResourcesFunc(t *testing.T) {
@@ -1697,6 +1700,338 @@ func TestModuleRangeFunc(t *testing.T) {
 				t.Fatal(err)
 			}
 
+			if diff := cmp.Diff(want.String(), got.Value.String()); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}
+
+func TestExprListFunc(t *testing.T) {
+	parse := func(src string, start hcl.Pos) hcl.Expression {
+		expr, diags := hclsyntax.ParseExpression([]byte(src), "main.tf", start)
+		if diags.HasErrors() {
+			t.Fatal(diags)
+		}
+		return expr
+	}
+
+	tests := []struct {
+		name   string
+		expr   hcl.Expression
+		want   []map[string]any
+		source string
+	}{
+		{
+			name: "static list",
+			expr: parse(`[foo, bar]`, hcl.Pos{Line: 1, Column: 8, Byte: 7}),
+			want: []map[string]any{
+				{
+					"value": "foo",
+					"range": map[string]any{
+						"filename": "main.tf",
+						"start": map[string]int{
+							"line":   1,
+							"column": 9,
+							"byte":   8,
+						},
+						"end": map[string]int{
+							"line":   1,
+							"column": 12,
+							"byte":   11,
+						},
+					},
+				},
+				{
+					"value": "bar",
+					"range": map[string]any{
+						"filename": "main.tf",
+						"start": map[string]int{
+							"line":   1,
+							"column": 14,
+							"byte":   13,
+						},
+						"end": map[string]int{
+							"line":   1,
+							"column": 17,
+							"byte":   16,
+						},
+					},
+				},
+			},
+			source: "attr = [foo, bar]",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			runner, diags := NewTestRunner(map[string]string{"main.tf": test.source})
+			if diags.HasErrors() {
+				t.Fatal(diags)
+			}
+
+			exprJSON, err := exprToJSON(test.expr, map[string]cty.Type{"expr": exprCty}, "expr", runner)
+			if err != nil {
+				t.Fatal(err)
+			}
+			input, err := ast.InterfaceToValue(exprJSON)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			ctx := rego.BuiltinContext{}
+			got, err := exprListFunc().Func(ctx, ast.NewTerm(input))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			want, err := ast.InterfaceToValue(test.want)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(want.String(), got.Value.String()); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}
+
+func TestExprMapFunc(t *testing.T) {
+	parse := func(src string, start hcl.Pos) hcl.Expression {
+		expr, diags := hclsyntax.ParseExpression([]byte(src), "main.tf", start)
+		if diags.HasErrors() {
+			t.Fatal(diags)
+		}
+		return expr
+	}
+
+	tests := []struct {
+		name   string
+		expr   hcl.Expression
+		want   []map[string]any
+		source string
+	}{
+		{
+			name: "static map",
+			expr: parse(`{ foo = 1, bar = 2 }`, hcl.Pos{Line: 1, Column: 8, Byte: 7}),
+			want: []map[string]any{
+				{
+					"key": map[string]any{
+						"value": "foo",
+						"range": map[string]any{
+							"filename": "main.tf",
+							"start": map[string]int{
+								"line":   1,
+								"column": 10,
+								"byte":   9,
+							},
+							"end": map[string]int{
+								"line":   1,
+								"column": 13,
+								"byte":   12,
+							},
+						},
+					},
+					"value": map[string]any{
+						"value": "1",
+						"range": map[string]any{
+							"filename": "main.tf",
+							"start": map[string]int{
+								"line":   1,
+								"column": 16,
+								"byte":   15,
+							},
+							"end": map[string]int{
+								"line":   1,
+								"column": 17,
+								"byte":   16,
+							},
+						},
+					},
+				},
+				{
+					"key": map[string]any{
+						"value": "bar",
+						"range": map[string]any{
+							"filename": "main.tf",
+							"start": map[string]int{
+								"line":   1,
+								"column": 19,
+								"byte":   18,
+							},
+							"end": map[string]int{
+								"line":   1,
+								"column": 22,
+								"byte":   21,
+							},
+						},
+					},
+					"value": map[string]any{
+						"value": "2",
+						"range": map[string]any{
+							"filename": "main.tf",
+							"start": map[string]int{
+								"line":   1,
+								"column": 25,
+								"byte":   24,
+							},
+							"end": map[string]int{
+								"line":   1,
+								"column": 26,
+								"byte":   25,
+							},
+						},
+					},
+				},
+			},
+			source: "attr = { foo = 1, bar = 2 }",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			runner, diags := NewTestRunner(map[string]string{"main.tf": test.source})
+			if diags.HasErrors() {
+				t.Fatal(diags)
+			}
+
+			exprJSON, err := exprToJSON(test.expr, map[string]cty.Type{"expr": exprCty}, "expr", runner)
+			if err != nil {
+				t.Fatal(err)
+			}
+			input, err := ast.InterfaceToValue(exprJSON)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			ctx := rego.BuiltinContext{}
+			got, err := exprMapFunc().Func(ctx, ast.NewTerm(input))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			want, err := ast.InterfaceToValue(test.want)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(want.String(), got.Value.String()); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}
+
+func TestExprCallFunc(t *testing.T) {
+	parse := func(src string, start hcl.Pos) hcl.Expression {
+		expr, diags := hclsyntax.ParseExpression([]byte(src), "main.tf", start)
+		if diags.HasErrors() {
+			t.Fatal(diags)
+		}
+		return expr
+	}
+
+	tests := []struct {
+		name   string
+		expr   hcl.Expression
+		want   map[string]any
+		source string
+	}{
+		{
+			name: "static call",
+			expr: parse(`foo("bar", "baz")`, hcl.Pos{Line: 1, Column: 8, Byte: 7}),
+			want: map[string]any{
+				"name": "foo",
+				"name_range": map[string]any{
+					"filename": "main.tf",
+					"start": map[string]int{
+						"line":   1,
+						"column": 8,
+						"byte":   7,
+					},
+					"end": map[string]int{
+						"line":   1,
+						"column": 11,
+						"byte":   10,
+					},
+				},
+				"arguments": []map[string]any{
+					{
+						"value": `"bar"`,
+						"range": map[string]any{
+							"filename": "main.tf",
+							"start": map[string]int{
+								"line":   1,
+								"column": 12,
+								"byte":   11,
+							},
+							"end": map[string]int{
+								"line":   1,
+								"column": 17,
+								"byte":   16,
+							},
+						},
+					},
+					{
+						"value": `"baz"`,
+						"range": map[string]any{
+							"filename": "main.tf",
+							"start": map[string]int{
+								"line":   1,
+								"column": 19,
+								"byte":   18,
+							},
+							"end": map[string]int{
+								"line":   1,
+								"column": 24,
+								"byte":   23,
+							},
+						},
+					},
+				},
+				"args_range": map[string]any{
+					"filename": "main.tf",
+					"start": map[string]int{
+						"line":   1,
+						"column": 11,
+						"byte":   10,
+					},
+					"end": map[string]int{
+						"line":   1,
+						"column": 25,
+						"byte":   24,
+					},
+				},
+			},
+			source: `attr = foo("bar", "baz")`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			runner, diags := NewTestRunner(map[string]string{"main.tf": test.source})
+			if diags.HasErrors() {
+				t.Fatal(diags)
+			}
+
+			exprJSON, err := exprToJSON(test.expr, map[string]cty.Type{"expr": exprCty}, "expr", runner)
+			if err != nil {
+				t.Fatal(err)
+			}
+			input, err := ast.InterfaceToValue(exprJSON)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			ctx := rego.BuiltinContext{}
+			got, err := exprCallFunc().Func(ctx, ast.NewTerm(input))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			want, err := ast.InterfaceToValue(test.want)
+			if err != nil {
+				t.Fatal(err)
+			}
 			if diff := cmp.Diff(want.String(), got.Value.String()); diff != "" {
 				t.Error(diff)
 			}


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint-ruleset-opa/issues/165

This PR adds the `expr` type as a schema type. The `expr` type differs from other types in that they do not immediately evaluate a value but instead return an expression structure. For example:

```hcl
variable "instance_type" {
  default = "t2.micro"
}

resource "aws_instance" "main" {
  instance_type = var.instance_type
}
```

### `string` type

```rego
terraform.resources("aws_instance", {"instance_type": "string"}, {})
```

```json
[
  {
    "type": "aws_instance",
    "name": "main",
    "config": {
      "instance_type": {
        "value": "t2.micro",
        "unknown": false,
        "sensitive": false,
        "ephemeral": false,
        "range": {...}
      }
    },
    "decl_range": {...}
  }
]
```

### `expr` type

```rego
terraform.resources("aws_instance", {"instance_type": "expr"}, {})
```

```json
[
  {
    "type": "aws_instance",
    "name": "main",
    "config": {
      "instance_type": {
        "value": "var.instance_type",
        "range": {...}
      }
    },
    "decl_range": {...}
  }
]
```

From the above, you can see that the expression representation (`var.instance_type`) is returned, not the result of evaluating `var.instance_type` (t2.micro). Note that attributes such as `unknown` are undefined because the expression has not been evaluated.

This is useful for writing policies over expression structures. For example, the `expr` type is the only way to handle meta-arguments such as `ignore_changes` that cannot be evaluated in the normal way.

The expression obtained by the `expr` type can be passed to the introduced `hcl.expr_list`, `hcl.expr_map`, and `hcl.expr_call` functions in this PR to perform static analysis of the expression structure. These functions are wrappers around [HCL static analysis functions](https://github.com/hashicorp/hcl/blob/v2.24.0/spec.md#static-analysis). For example, you can use `hcl.expr_list` to check for references in `ignore_changes`:

```hcl
resource "aws_instance" "main" {
  lifecycle {
    ignore_changes = [key_name, tags]
  }
}
```

```rego
resources := terraform.resources("*", {"lifecycle": {"ignore_changes": "expr"}}, {"expand_mode": "none"})
ignore_changes := resources[i].config.lifecycle[j].config.ignore_changes

# Does "ignore_changes" have "tags"?
some k
hcl.expr_list(ignore_changes)[k].value == "tags"
```

We have deliberately not introduced functions for static traversal. Perhaps you will need an API like [`lang.ReferencesInExpr`](https://github.com/terraform-linters/tflint-plugin-sdk/blob/v0.22.0/terraform/lang/references.go#L53), but it is not yet clear what kind of API you will need, so we will consider adding it upon request.

