### PR TITLE
Decoupling the gorelease release pipeline 

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -41,9 +41,7 @@ signs:
       - '${artifact}'
       - --yes
 release:
-  github:
-    owner: terraform-linters
-    name: tflint-ruleset-opa
+  github: {}
   draft: true
 snapshot:
   version_template: "{{ .Tag }}-dev"


### PR DESCRIPTION
noticed this when working in a fork of the original project. The gorelease pipelines have been hard coded with the github repo owner and project name. 

This small change will allow others to run the actions(un modified) if they decide to fork the project and it also decouples the code base from platform if author ever decides to move the code or rename the repo

According to [GoReleaser](https://goreleaser.com/customization/release/), 

```
release:
  # Repo in which the release will be created.
  # Default: extracted from the origin remote URL or empty if its private hosted.
```